### PR TITLE
Add JSON Struct Tag to CarrierAccount.Fields

### DIFF
--- a/carrier.go
+++ b/carrier.go
@@ -24,13 +24,13 @@ type CarrierFields struct {
 // CarrierAccount encapsulates credentials and other information related to a
 // carrier account.
 type CarrierAccount struct {
-	ID              string     `json:"id,omitempty"`
-	Object          string     `json:"object,omitempty"`
-	Reference       string     `json:"reference,omitempty"`
-	CreatedAt       *time.Time `json:"created_at,omitempty"`
-	UpdatedAt       *time.Time `json:"updated_at,omitempty"`
-	Type            string     `json:"type,omitempty"`
-	Fields          *CarrierFields
+	ID              string            `json:"id,omitempty"`
+	Object          string            `json:"object,omitempty"`
+	Reference       string            `json:"reference,omitempty"`
+	CreatedAt       *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt       *time.Time        `json:"updated_at,omitempty"`
+	Type            string            `json:"type,omitempty"`
+	Fields          *CarrierFields    `json:"fields,omitempty"`
 	Clone           bool              `json:"clone,omitempty"`
 	Description     string            `json:"description,omitempty"`
 	Readable        string            `json:"readable,omitempty"`


### PR DESCRIPTION
### What It Fixes ###
The CarrierAccount.Fields field did not have a `json` struct tag. This caused JSON to serialize it using the key "Fields" (capitalized), and it would include it even if it was nil.

This change simply adds the appropriate struct tag so that the correct key will be used, and also so that we don't serialize the field to JSON if it is empty.