### PR TITLE
Properly Send Optional carrier_accounts Parameter When Creating Shipment 

### DIFF
--- a/shipment.go
+++ b/shipment.go
@@ -156,13 +156,6 @@ type Shipment struct {
 	BatchMessage      string            `json:"batch_message,omitempty"`
 }
 
-type createShipmentRequest struct {
-	Shipment struct {
-		*Shipment
-		CarrierAccountIDs []string `json:"carrier_accounts,omitempty"`
-	} `json:"shipment,omitempty"`
-}
-
 // CreateShipment creates a new Shipment object. The ToAddress, FromAddress and
 // Parcel attributes are required. These objects may be fully-specified to
 // create new ones at the same time as creating the Shipment, or they can refer

--- a/shipment.go
+++ b/shipment.go
@@ -156,8 +156,10 @@ type Shipment struct {
 }
 
 type createShipmentRequest struct {
-	Shipment        *Shipment         `json:"shipment,omitempty"`
-	CarrierAccounts []*CarrierAccount `json:"carrier_accounts,omitempty"`
+	Shipment struct {
+		*Shipment
+		CarrierAccountIDs []string `json:"carrier_accounts,omitempty"`
+	} `json:"shipment,omitempty"`
 }
 
 // CreateShipment creates a new Shipment object. The ToAddress, FromAddress and
@@ -190,16 +192,24 @@ type createShipmentRequest struct {
 //		},
 //	)
 func (c *Client) CreateShipment(in *Shipment, accounts ...*CarrierAccount) (out *Shipment, err error) {
-	req := &createShipmentRequest{Shipment: in, CarrierAccounts: accounts}
-	err = c.post(nil, "shipments", req, &out)
+	var req createShipmentRequest
+	req.Shipment.Shipment = in
+	if len(accounts) > 0 {
+		req.Shipment.CarrierAccountIDs = []string{accounts[0].ID}
+	}
+	err = c.post(nil, "shipments", &req, &out)
 	return
 }
 
 // CreateShipmentWithContext performs the same operation as CreateShipment, but
 // allows specifying a context that can interrupt the request.
 func (c *Client) CreateShipmentWithContext(ctx context.Context, in *Shipment, accounts ...*CarrierAccount) (out *Shipment, err error) {
-	req := &createShipmentRequest{Shipment: in, CarrierAccounts: accounts}
-	err = c.post(ctx, "shipments", req, &out)
+	var req createShipmentRequest
+	req.Shipment.Shipment = in
+	if len(accounts) > 0 {
+		req.Shipment.CarrierAccountIDs = []string{accounts[0].ID}
+	}
+	err = c.post(ctx, "shipments", &req, &out)
 	return
 }
 

--- a/shipment.go
+++ b/shipment.go
@@ -121,38 +121,39 @@ type ShipmentOptions struct {
 // addresses, the Parcel being shipped, and any customs forms required for
 // international deliveries.
 type Shipment struct {
-	ID            string            `json:"id,omitempty"`
-	Object        string            `json:"object,omitempty"`
-	Reference     string            `json:"reference,omitempty"`
-	Mode          string            `json:"mode,omitempty"`
-	CreatedAt     *time.Time        `json:"created_at,omitempty"`
-	UpdatedAt     *time.Time        `json:"updated_at,omitempty"`
-	ToAddress     *Address          `json:"to_address,omitempty"`
-	FromAddress   *Address          `json:"from_address,omitempty"`
-	ReturnAddress *Address          `json:"return_address,omitempty"`
-	BuyerAddress  *Address          `json:"buyer_address,omitempty"`
-	Parcel        *Parcel           `json:"parcel,omitempty"`
-	Carrier       string            `json:"carrier,omitempty"`
-	Service       string            `json:"service,omitempty"`
-	CustomsInfo   *CustomsInfo      `json:"customs_info,omitempty"`
-	ScanForm      *ScanForm         `json:"scan_form,omitempty"`
-	Forms         []*Form           `json:"forms,omitempty"`
-	Insurance     string            `json:"insurance,omitempty"`
-	Rates         []*Rate           `json:"rates,omitempty"`
-	SelectedRate  *Rate             `json:"selected_rate,omitempty"`
-	PostageLabel  *PostageLabel     `json:"postage_label,omitempty"`
-	Messages      []*CarrierMessage `json:"messages,omitempty"`
-	Options       *ShipmentOptions  `json:"options,omitempty"`
-	IsReturn      bool              `json:"is_return,omitempty"`
-	TrackingCode  string            `json:"tracking_code,omitempty"`
-	USPSZone      int               `json:"usps_zone,omitempty"`
-	Status        string            `json:"status,omitempty"`
-	Tracker       *Tracker          `json:"tracker,omitempty"`
-	Fees          []*Fee            `json:"fees,omitempty"`
-	RefundStatus  string            `json:"refund_status,omitempty"`
-	BatchID       string            `json:"batch_id,omitempty"`
-	BatchStatus   string            `json:"batch_status,omitempty"`
-	BatchMessage  string            `json:"batch_message,omitempty"`
+	ID                string            `json:"id,omitempty"`
+	Object            string            `json:"object,omitempty"`
+	Reference         string            `json:"reference,omitempty"`
+	Mode              string            `json:"mode,omitempty"`
+	CreatedAt         *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt         *time.Time        `json:"updated_at,omitempty"`
+	ToAddress         *Address          `json:"to_address,omitempty"`
+	FromAddress       *Address          `json:"from_address,omitempty"`
+	ReturnAddress     *Address          `json:"return_address,omitempty"`
+	BuyerAddress      *Address          `json:"buyer_address,omitempty"`
+	Parcel            *Parcel           `json:"parcel,omitempty"`
+	Carrier           string            `json:"carrier,omitempty"`
+	Service           string            `json:"service,omitempty"`
+	CarrierAccountIDs []string          `json:"carrier_accounts,omitempty"`
+	CustomsInfo       *CustomsInfo      `json:"customs_info,omitempty"`
+	ScanForm          *ScanForm         `json:"scan_form,omitempty"`
+	Forms             []*Form           `json:"forms,omitempty"`
+	Insurance         string            `json:"insurance,omitempty"`
+	Rates             []*Rate           `json:"rates,omitempty"`
+	SelectedRate      *Rate             `json:"selected_rate,omitempty"`
+	PostageLabel      *PostageLabel     `json:"postage_label,omitempty"`
+	Messages          []*CarrierMessage `json:"messages,omitempty"`
+	Options           *ShipmentOptions  `json:"options,omitempty"`
+	IsReturn          bool              `json:"is_return,omitempty"`
+	TrackingCode      string            `json:"tracking_code,omitempty"`
+	USPSZone          int               `json:"usps_zone,omitempty"`
+	Status            string            `json:"status,omitempty"`
+	Tracker           *Tracker          `json:"tracker,omitempty"`
+	Fees              []*Fee            `json:"fees,omitempty"`
+	RefundStatus      string            `json:"refund_status,omitempty"`
+	BatchID           string            `json:"batch_id,omitempty"`
+	BatchStatus       string            `json:"batch_status,omitempty"`
+	BatchMessage      string            `json:"batch_message,omitempty"`
 }
 
 type createShipmentRequest struct {
@@ -191,24 +192,20 @@ type createShipmentRequest struct {
 //			CustomsInfo: &easypost.CustomsInfo{ID: "cstinfo_1"},
 //		},
 //	)
-func (c *Client) CreateShipment(in *Shipment, accounts ...*CarrierAccount) (out *Shipment, err error) {
-	var req createShipmentRequest
-	req.Shipment.Shipment = in
-	if len(accounts) > 0 {
-		req.Shipment.CarrierAccountIDs = []string{accounts[0].ID}
-	}
+func (c *Client) CreateShipment(in *Shipment) (out *Shipment, err error) {
+	req := struct {
+		Shipment *Shipment `json:"shipment"`
+	}{Shipment: in}
 	err = c.post(nil, "shipments", &req, &out)
 	return
 }
 
 // CreateShipmentWithContext performs the same operation as CreateShipment, but
 // allows specifying a context that can interrupt the request.
-func (c *Client) CreateShipmentWithContext(ctx context.Context, in *Shipment, accounts ...*CarrierAccount) (out *Shipment, err error) {
-	var req createShipmentRequest
-	req.Shipment.Shipment = in
-	if len(accounts) > 0 {
-		req.Shipment.CarrierAccountIDs = []string{accounts[0].ID}
-	}
+func (c *Client) CreateShipmentWithContext(ctx context.Context, in *Shipment) (out *Shipment, err error) {
+	req := struct {
+		Shipment *Shipment `json:"shipment"`
+	}{Shipment: in}
 	err = c.post(ctx, "shipments", &req, &out)
 	return
 }


### PR DESCRIPTION
### What It Fixes ###
The _CreateShipment_ method supports an optional carrier account ID parameter. If specified along with providing a service on the shipment object, shipments can be created and bought with one request.

Previously, we were not sending the optional carrier account parameter in the right way, which caused the API to return an error. This change fixes that bug.

### How I Tested It ###
I re-ran existing automated tests and made sure they pass. I did not want to add an automated test for the "create and buy" functionality, as this requires billing in order to succeed. I did, however, write a test program and verify that it worked:

```go
package main

import (
	"encoding/json"
	"flag"
	"fmt"
	"os"

	"github.com/EasyPost/easypost-go"
)

func main() {
	key := flag.String("api-key", "", "API key")
	flag.Parse()
	client := easypost.New(*key)

	accounts, err := client.ListCarrierAccounts()
	if err != nil {
		fmt.Fprintln(os.Stderr, "error:", err)
		os.Exit(1)
	}
	var uspsAccount *easypost.CarrierAccount
	for _, account := range accounts {
		if account.Readable == "USPS" {
			uspsAccount = account
			break
		}
	}

	if uspsAccount == nil {
		fmt.Fprintln(os.Stderr, "error: could not find USPS account")
		os.Exit(1)
	}

	shipment, err := client.CreateShipment(
		&easypost.Shipment{
			ToAddress: &easypost.Address{
				Name:    "Bugs Bunny",
				Street1: "4000 Warner Blvd",
				City:    "Burbank",
				State:   "CA",
				Zip:     "91522",
			},
			FromAddress: &easypost.Address{
				Company: "EasyPost",
				Street1: "One Montgomery St",
				Street2: "Ste 400",
				City:    "San Francisco",
				State:   "CA",
				Zip:     "94104",
				Phone:   "415-555-1212",
			},
			Parcel: &easypost.Parcel{
				Length: 10.2,
				Width:  7.8,
				Height: 4.3,
				Weight: 21.2,
			},
			CustomsInfo: &easypost.CustomsInfo{
				CustomsCertify:    true,
				CustomsSigner:     "Wile E. Coyote",
				ContentsType:      "gift",
				EELPFC:            "NOEEI 30.37(a)",
				NonDeliveryOption: "return",
				RestrictionType:   "none",
				CustomsItems: []*easypost.CustomsItem{
					&easypost.CustomsItem{
						Description:    "EasyPost t-shirts",
						HSTariffNumber: "123456",
						OriginCountry:  "US",
						Quantity:       2,
						Value:          96.27,
						Weight:         21.1,
					},
				},
			},
			Service:           "Priority",
			CarrierAccountIDs: []string{uspsAccount.ID},
		},
	)

	if err != nil {
		buf, _ := json.MarshalIndent(err, "", "  ")
		fmt.Fprintf(os.Stderr, "error: %s\n", buf)
		os.Exit(1)
	}

	buf, _ := json.MarshalIndent(shipment, "", "  ")
	fmt.Println(string(buf))
}
```