### PR TITLE
install instruction shouldnt say https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation
 ------------
 
 ```bash
-go get -u https://github.com/EasyPost/easypost-go
+go get -u github.com/EasyPost/easypost-go
 ```
 
 


### PR DESCRIPTION
👋 hello! I was looking for projects to learn a bit of go, and noticed this had easy install instructions, but then they were not working correctly!

This PR should fix the instructions, as `https://` doesn't work

cc @richshaffer or @bkeyoumarsi perhaps as contributors to the repo!