### PR TITLE
add travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: go
+script: go get github.com/EasyPost/easypost-go &&  go test ./tests/

--- a/tests/insurance_test.go
+++ b/tests/insurance_test.go
@@ -46,6 +46,8 @@ func TestInsuranceCreation(t *testing.T) {
 			Amount:       "101.00",
 		},
 	)
+	require.NoError(err)
+
 	assert.NotNil(insurance.ToAddress)
 	assert.NotNil(insurance.FromAddress)
 	assert.NotNil(insurance.Tracker)


### PR DESCRIPTION
This PR adds a `travis-ci.yml` file to automate running of travis CI for every pull request.

however! Travis will complain that there's no API keys set. So one this PR merges, someone from EasyPost will need to configure some environment variables in the travis profile as described here: https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings