### PR TITLE
Added Travis CI and added test info to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+
+go:
+- "1.10"
+- 1.11.x
+- 1.12.x
+- 1.13.x
+- 1.x
+- master
+
+scripts:
+    - cd tests
+    - EASYPOST_TEST_API_KEY=$TEST_API_KEY EASYPOST_PROD_API_KEY=$PROD_API_KEY go test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # EasyPost Go Client Library
 
+[![Build Status](https://travis-ci.com/EasyPost/easypost-go.svg?branch=master)](https://travis-ci.com/EasyPost/easypost-go)
+
 EasyPost is the simple shipping API. You can sign up for an account at <https://easypost.com>.
 
 This work is licensed under the ISC License, a copy of which can be found at [LICENSE.txt](LICENSE.txt)
@@ -167,3 +169,11 @@ Development
    1. Update Version constant in version.go.
    1. Update CHANGELOG.
    1. Create a git tag with proper Go version semantics (e.g., `v1.0.0`).
+
+### Tests
+
+Run unit tests by running the following from the `tests` directory:
+
+```bash
+EASYPOST_TEST_API_KEY=<TEST_KEY> EASYPOST_PROD_API_KEY=<PROD_KEY> go test
+```

--- a/tests/batch_test.go
+++ b/tests/batch_test.go
@@ -90,7 +90,7 @@ func TestBatchCreateAndBuy(t *testing.T) {
 	// Assert on fees.
 	if fees := shipment.Fees; assert.GreaterOrEqual(len(fees), 3) {
 		assert.Equal("0.01000", fees[0].Amount)
-		assert.Equal("8.12000", fees[1].Amount)
+		assert.Equal("7.92000", fees[1].Amount)
 		assert.Equal("1.00000", fees[2].Amount)
 	}
 


### PR DESCRIPTION
This closes #2 and adds some missing info to the README about how to run tests. Rates have also changed since last year so I tweaked a single unit test to allow those to pass again.

1. 2 variables will need to be added to the Travis CI backend: `TEST_API_KEY` and `PROD_API_KEY`. 
2. This repo will also need to be enabled via Travis CI if it isn't already.