### PR TITLE
Added examples for various objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/examples/addresses/create_address.go
+++ b/examples/addresses/create_address.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Create and verify an address
+	toAddress, err := client.CreateAddress(
+		&easypost.Address{
+			Name:    "Bugs Bunny",
+			Street1: "4000 Warner Blvd",
+			City:    "Burbank",
+			State:   "CA",
+			Zip:     "91522",
+		},
+		&easypost.CreateAddressOptions{Verify: []string{"delivery"}},
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating to address:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(toAddress, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/addresses/retrieve_address.go
+++ b/examples/addresses/retrieve_address.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Retrieve an address
+	address, err := client.GetAddress("adr_123")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving address:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(address, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/addresses/retrieve_addresses.go
+++ b/examples/addresses/retrieve_addresses.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Retrieve a list of addresses
+	address, err := client.ListAddresses(
+		&easypost.ListOptions{
+			// options here
+		},
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving address:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(address, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/batches/create_batch.go
+++ b/examples/batches/create_batch.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Create a batch
+	batch, err := client.CreateBatch(
+		&easypost.Shipment{ID: "shp_100"},
+		&easypost.Shipment{ID: "shp_101"},
+		&easypost.Shipment{ID: "shp_102"},
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating batch:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(batch, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/batches/retrieve_batch.go
+++ b/examples/batches/retrieve_batch.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Retrieve an batch
+	batch, err := client.GetBatch("batch_123")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving batch:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(batch, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/batches/retrieve_batches.go
+++ b/examples/batches/retrieve_batches.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Retrieve an batch
+	batch, err := client.ListBatches(
+		&easypost.ListOptions{
+			// options here
+		},
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving batch:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(batch, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/parcels/create_parcel.go
+++ b/examples/parcels/create_parcel.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Create a parcel
+	parcel, err := client.CreateParcel(
+		&easypost.Parcel{
+			Length: 10.2,
+			Width:  7.8,
+			Height: 4.3,
+			Weight: 21.2,
+		},
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating parcel:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(parcel, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/parcels/retrieve_parcel.go
+++ b/examples/parcels/retrieve_parcel.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Retrieve a parcel
+	parcel, err := client.GetParcel("prcl_123")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving parcel:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(parcel, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/scanforms/create_scanform.go
+++ b/examples/scanforms/create_scanform.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Create and verify an address
+	toAddress, err := client.CreateScanForm(
+		"shp_100",
+		"shp_101",
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating to address:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(toAddress, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/scanforms/retrieve_scanform.go
+++ b/examples/scanforms/retrieve_scanform.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Retrieve an scanform
+	scanform, err := client.GetScanForm("scanform_123")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving scanform:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(scanform, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/scanforms/retrieve_scanforms.go
+++ b/examples/scanforms/retrieve_scanforms.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Retrieve a list of scanforms
+	scanforms, err := client.ListScanForms(
+		&easypost.ListOptions{
+			// options here
+		},
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving scanforms:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(scanforms, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/shipments/buy_shipment.go
+++ b/examples/shipments/buy_shipment.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Buy a postage label with one of the rate objects and optional insurance
+	// client.BuyShipment(shipment, rate, insurance)
+	shipment, err := client.BuyShipment("shp_123", &easypost.Rate{ID: "rate_123"}, "")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error buying shipment:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(shipment, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/shipments/retrieve_shipment.go
+++ b/examples/shipments/retrieve_shipment.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Retrieve a shipment
+	shipment, err := client.GetShipment("shp_123")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving shipment:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(shipment, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}

--- a/examples/shipments/retrieve_shipments.go
+++ b/examples/shipments/retrieve_shipments.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/EasyPost/easypost-go"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Retrieve a list of shipments
+	shipments, err := client.ListShipments(
+		&easypost.ListShipmentsOptions{
+			// options here
+		},
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving shipments:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(shipments, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}


### PR DESCRIPTION
The Go library didn't have any examples like many of our other libraries. This PR adds various basic examples for objects like addresses, parcels, shipments, scanforms, and batches. Additionally, the example on the README threw various type errors so that example has been corrected in this PR too.