### PR TITLE
Fix issue in performing list operations with query params

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
-=== 1.0.0 2019-09-03
+=== 1.0.3 2020-05-30
 
- * Initial release.
+ * Fix issue in List actions that take query parameters
+
+=== 1.0.2 2020-05-08
+
+ * Add shipment options for certified and registered mail.
+ * Changes to unit tests.
 
 === 1.0.1 2020-03-17
 
@@ -14,7 +19,8 @@
    key name when serialized to JSON. Prior to this change, values in the Fields
    field were not recognized by the API.
 
-=== 1.0.2 2020-05-08
+=== 1.0.0 2019-09-03
 
- * Add shipment options for certified and registered mail.
- * Changes to unit tests.
+ * Initial release.
+
+

--- a/address.go
+++ b/address.go
@@ -117,14 +117,13 @@ type ListAddressResult struct {
 
 // ListAddresses provides a paginated result of InsuAddressrance objects.
 func (c *Client) ListAddresses(opts *ListOptions) (out *ListAddressResult, err error) {
-	err = c.do(nil, http.MethodGet, "addresses", &opts, &out)
-	return
+	return c.ListAddressesWithContext(nil, opts)
 }
 
 // ListAddressesWithContext performs the same operation as ListAddresses, but
 // allows specifying a context that can interrupt the request.
 func (c *Client) ListAddressesWithContext(ctx context.Context, opts *ListOptions) (out *ListAddressResult, err error) {
-	err = c.do(ctx, http.MethodGet, "addresses", &opts, &out)
+	err = c.do(ctx, http.MethodGet, "addresses", c.convertOptsToURLValues(opts), &out)
 	return
 }
 

--- a/batch.go
+++ b/batch.go
@@ -87,14 +87,13 @@ type ListBatchesResult struct {
 
 // ListBatches provides a paginated result of Insurance objects.
 func (c *Client) ListBatches(opts *ListOptions) (out *ListBatchesResult, err error) {
-	err = c.do(nil, http.MethodGet, "batches", &opts, &out)
-	return
+	return c.ListBatchesWithContext(nil, opts)
 }
 
 // ListBatchesWithContext performs the same operation as ListBatches, but
 // allows specifying a context that can interrupt the request.
 func (c *Client) ListBatchesWithContext(ctx context.Context, opts *ListOptions) (out *ListBatchesResult, err error) {
-	err = c.do(ctx, http.MethodGet, "batches", &opts, &out)
+	err = c.do(ctx, http.MethodGet, "batches", c.convertOptsToURLValues(opts), &out)
 	return
 }
 

--- a/client.go
+++ b/client.go
@@ -8,6 +8,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/google/go-querystring/query"
 )
 
 const defaultUserAgent = "EasyPost/v2 GoClient/" + Version
@@ -61,9 +63,14 @@ func (c *Client) client() *http.Client {
 	return http.DefaultClient
 }
 
+func (c *Client) convertOptsToURLValues(v interface{}) *url.Values {
+	values, _ := query.Values(v)
+	return &values
+}
+
 func (c *Client) setBody(req *http.Request, in interface{}) error {
 	switch in := in.(type) {
-	case url.Values:
+	case *url.Values:
 		buf := []byte(in.Encode())
 		req.Body = ioutil.NopCloser(bytes.NewReader(buf))
 		req.GetBody = func() (io.ReadCloser, error) {

--- a/client.go
+++ b/client.go
@@ -63,14 +63,14 @@ func (c *Client) client() *http.Client {
 	return http.DefaultClient
 }
 
-func (c *Client) convertOptsToURLValues(v interface{}) *url.Values {
+func (c *Client) convertOptsToURLValues(v interface{}) url.Values {
 	values, _ := query.Values(v)
-	return &values
+	return values
 }
 
 func (c *Client) setBody(req *http.Request, in interface{}) error {
 	switch in := in.(type) {
-	case *url.Values:
+	case url.Values:
 		buf := []byte(in.Encode())
 		req.Body = ioutil.NopCloser(bytes.NewReader(buf))
 		req.GetBody = func() (io.ReadCloser, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.12
 
 require (
 	github.com/dnaeon/go-vcr v1.0.1
+	github.com/google/go-querystring v1.0.0
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/insurance.go
+++ b/insurance.go
@@ -74,14 +74,13 @@ type ListInsurancesResult struct {
 
 // ListInsurances provides a paginated result of Insurance objects.
 func (c *Client) ListInsurances(opts *ListOptions) (out *ListInsurancesResult, err error) {
-	err = c.do(nil, http.MethodGet, "insurances", &opts, &out)
-	return
+	return c.ListInsurancesWithContext(nil, opts)
 }
 
 // ListInsurancesWithContext performs the same operation as ListInsurances, but
 // allows specifying a context that can interrupt the request.
 func (c *Client) ListInsurancesWithContext(ctx context.Context, opts *ListOptions) (out *ListInsurancesResult, err error) {
-	err = c.do(ctx, http.MethodGet, "insurances", &opts, &out)
+	err = c.do(ctx, http.MethodGet, "insurances", c.convertOptsToURLValues(opts), &out)
 	return
 }
 

--- a/list_options.go
+++ b/list_options.go
@@ -4,9 +4,9 @@ import "time"
 
 // ListOptions is used to specify query parameters for listing EasyPost objects.
 type ListOptions struct {
-	BeforeID      string     `json:"before_id,omitempty"`
-	AfterID       string     `json:"after_id,omitempty"`
-	StartDateTime *time.Time `json:"start_datetime,omitempty"`
-	EndDateTime   *time.Time `json:"end_datetime,omitempty"`
-	PageSize      int        `json:"page_size,omitempty"`
+	BeforeID      string     `url:"before_id,omitempty"`
+	AfterID       string     `url:"after_id,omitempty"`
+	StartDateTime *time.Time `url:"start_datetime,omitempty"`
+	EndDateTime   *time.Time `url:"end_datetime,omitempty"`
+	PageSize      int        `url:"page_size,omitempty"`
 }

--- a/report.go
+++ b/report.go
@@ -46,11 +46,11 @@ func (c *Client) CreateReportWithContext(ctx context.Context, typ string, in *Re
 // ListReportsOptions is used to specify query parameters for listing Report
 // objects.
 type ListReportsOptions struct {
-	BeforeID  string `json:"before_id,omitempty"`
-	AfterID   string `json:"after_id,omitempty"`
-	StartDate string `json:"start_datetime,omitempty"`
-	EndDate   string `json:"end_datetime,omitempty"`
-	PageSize  int    `json:"page_size,omitempty"`
+	BeforeID  string `url:"before_id,omitempty"`
+	AfterID   string `url:"after_id,omitempty"`
+	StartDate string `url:"start_datetime,omitempty"`
+	EndDate   string `url:"end_datetime,omitempty"`
+	PageSize  int    `url:"page_size,omitempty"`
 }
 
 // ListReportsResult holds the results from the list reports API.
@@ -65,14 +65,13 @@ type ListReportsResult struct {
 
 // ListReports provides a paginated result of Report objects of the given type.
 func (c *Client) ListReports(typ string, opts *ListReportsOptions) (out *ListReportsResult, err error) {
-	err = c.do(nil, http.MethodGet, "reports/"+typ, &opts, &out)
-	return
+	return c.ListReportsWithContext(nil, typ, opts)
 }
 
 // ListReportsWithContext performs the same operation as ListReports, but allows
 // specifying a context that can interrupt the request.
 func (c *Client) ListReportsWithContext(ctx context.Context, typ string, opts *ListReportsOptions) (out *ListReportsResult, err error) {
-	err = c.do(ctx, http.MethodGet, "reports/"+typ, &opts, &out)
+	err = c.do(ctx, http.MethodGet, "reports/"+typ, c.convertOptsToURLValues(opts), &out)
 	return
 }
 

--- a/scan_form.go
+++ b/scan_form.go
@@ -65,14 +65,13 @@ type ListScanFormsResult struct {
 
 // ListScanForms provides a paginated result of ScanForm objects.
 func (c *Client) ListScanForms(opts *ListOptions) (out *ListScanFormsResult, err error) {
-	err = c.do(nil, http.MethodGet, "scan_forms", &opts, &out)
-	return
+	return c.ListScanFormsWithContext(nil, opts)
 }
 
 // ListScanFormsWithContext performs the same operation as ListScanForms, but
 // allows specifying a context that can interrupt the request.
 func (c *Client) ListScanFormsWithContext(ctx context.Context, opts *ListOptions) (out *ListScanFormsResult, err error) {
-	err = c.do(ctx, http.MethodGet, "scan_forms", &opts, &out)
+	err = c.do(ctx, http.MethodGet, "scan_forms", c.convertOptsToURLValues(opts), &out)
 	return
 }
 

--- a/shipment.go
+++ b/shipment.go
@@ -210,13 +210,13 @@ func (c *Client) CreateShipmentWithContext(ctx context.Context, in *Shipment) (o
 // ListShipmentsOptions is used to specify query parameters for listing Shipment
 // objects.
 type ListShipmentsOptions struct {
-	BeforeID        string     `json:"before_id,omitempty"`
-	AfterID         string     `json:"after_id,omitempty"`
-	StartDateTime   *time.Time `json:"start_datetime,omitempty"`
-	EndDateTime     *time.Time `json:"end_datetime,omitempty"`
-	PageSize        int        `json:"page_size,omitempty"`
-	Purchased       bool       `json:"purchased,omitempty"`
-	IncludeChildren bool       `json:"include_children,omitempty"`
+	BeforeID        string     `url:"before_id,omitempty"`
+	AfterID         string     `url:"after_id,omitempty"`
+	StartDateTime   *time.Time `url:"start_datetime,omitempty"`
+	EndDateTime     *time.Time `url:"end_datetime,omitempty"`
+	PageSize        int        `url:"page_size,omitempty"`
+	Purchased       *bool      `url:"purchased,omitempty"`
+	IncludeChildren *bool      `url:"include_children,omitempty"`
 }
 
 // ListShipmentsResult holds the results from the list shipments API.
@@ -231,14 +231,13 @@ type ListShipmentsResult struct {
 
 // ListShipments provides a paginated result of Shipment objects.
 func (c *Client) ListShipments(opts *ListShipmentsOptions) (out *ListShipmentsResult, err error) {
-	err = c.do(nil, http.MethodGet, "shipments", &opts, &out)
-	return
+	return c.ListShipmentsWithContext(nil, opts)
 }
 
 // ListShipmentsWithContext performs the same operation as ListShipments, but
 // allows specifying a context that can interrupt the request.
 func (c *Client) ListShipmentsWithContext(ctx context.Context, opts *ListShipmentsOptions) (out *ListShipmentsResult, err error) {
-	err = c.do(ctx, http.MethodGet, "shipments", &opts, &out)
+	err = c.do(ctx, http.MethodGet, "shipments", c.convertOptsToURLValues(opts), &out)
 	return
 }
 

--- a/tests/shipment_test.go
+++ b/tests/shipment_test.go
@@ -148,3 +148,16 @@ func (c *ClientTests) TestShipmentCreation() {
 		)
 	}
 }
+
+func (c *ClientTests) TestShipmentList() {
+	client := c.TestClient()
+	assert, require := c.Assert(), c.Require()
+
+	out, err := client.ListShipments(&easypost.ListShipmentsOptions{
+		Purchased:       easypost.BoolPtr(false),
+		IncludeChildren: easypost.BoolPtr(false),
+	})
+	require.NoError(err)
+	require.NotEmpty(out)
+	assert.True(len(out.Shipments) > 0)
+}

--- a/tests/testdata/TestClient/TestShipmentList.yaml
+++ b/tests/testdata/TestClient/TestShipmentList.yaml
@@ -1,0 +1,58 @@
+---
+version: 1
+interactions:
+- request:
+    body: include_children=false&purchased=false
+    form: {}
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - EasyPost/v2 GoClient/1.0.3
+    url: https://api.easypost.com/v2/shipments
+    method: GET
+  response:
+    body: '{"shipments":[{"created_at":"2020-05-30T01:43:58Z","is_return":false,"messages":[{"carrier":"EasyPost","carrier_account_id":"ca_c3c24e1bf39949c9b17bdb608c879bdc","type":"rate_error","message":"this
+      service is no longer available"}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2020-05-30T01:44:01Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_174f863f759943b48b8c2580fd6ea48e","object":"Address","created_at":"2020-05-30T01:43:58Z","updated_at":"2020-05-30T01:43:58Z","name":"Dr.
+      Steve Brule","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
+      Beach","state":"CA","zip":"90277","country":"US","phone":"8573875756","email":"dr_steve_brule@gmail.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_19bf7f5ebd074d3f8ec7e136487f5213","object":"Parcel","created_at":"2020-05-30T01:43:58Z","updated_at":"2020-05-30T01:43:58Z","length":20.2,"width":10.9,"height":5.0,"predefined_package":null,"weight":65.9,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_18412360876d4d93ae4ce1c6d06624d2","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"Priority","carrier":"USPS","rate":"8.04","currency":"USD","retail_rate":"10.20","retail_currency":"USD","list_rate":"8.04","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_ad6004b084b34b9bbe99ae4596bed102"},{"id":"rate_05f08696c66f450686be2d43d01be15e","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.94","currency":"USD","retail_rate":"7.94","retail_currency":"USD","list_rate":"7.94","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_ad6004b084b34b9bbe99ae4596bed102"},{"id":"rate_17455dbf942c4c11a858fbb5aa6c45ae","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"Express","carrier":"USPS","rate":"24.00","currency":"USD","retail_rate":"28.35","retail_currency":"USD","list_rate":"24.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_ad6004b084b34b9bbe99ae4596bed102"},{"id":"rate_cd191d3c75944397a39d05f721dd2b47","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"GroundReturn","carrier":"USPSReturns","rate":"10.20","currency":"USD","retail_rate":"10.20","retail_currency":"USD","list_rate":"10.20","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_7131ba0a94ec41839b710437cfbd7abd"},{"id":"rate_e4c7e3f2a500476baf919d1d3872e98f","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"PriorityMailReturn","carrier":"USPSReturns","rate":"8.04","currency":"USD","retail_rate":"10.20","retail_currency":"USD","list_rate":"8.04","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_7131ba0a94ec41839b710437cfbd7abd"},{"id":"rate_cd9abeaec5b9458d812df2d08d85f9a2","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.67","currency":"USD","retail_rate":"11.37","retail_currency":"USD","list_rate":"11.08","list_currency":"USD","delivery_days":1,"delivery_date":"2020-06-02T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_2b140da0c45a4952ad42883edc0425ef"},{"id":"rate_a835c175c96f45d6b5a0a173014dabce","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"17.96","currency":"USD","retail_rate":"17.10","retail_currency":"USD","list_rate":"17.29","list_currency":"USD","delivery_days":3,"delivery_date":"2020-06-04T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_2b140da0c45a4952ad42883edc0425ef"},{"id":"rate_1bb509cab4ab44cdb2857aca8dc94689","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"2ndDayAirAM","carrier":"UPS","rate":"26.04","currency":"USD","retail_rate":"25.42","retail_currency":"USD","list_rate":"25.07","list_currency":"USD","delivery_days":2,"delivery_date":"2020-06-02T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_2b140da0c45a4952ad42883edc0425ef"},{"id":"rate_d82a4982853746ccbe111d3b1e33db0b","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"24.62","currency":"USD","retail_rate":"22.44","retail_currency":"USD","list_rate":"23.48","list_currency":"USD","delivery_days":2,"delivery_date":"2020-06-02T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_2b140da0c45a4952ad42883edc0425ef"},{"id":"rate_7f884d57a2b045c38d1ec2ff9b6902b4","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"41.63","currency":"USD","retail_rate":"37.91","retail_currency":"USD","list_rate":"40.06","list_currency":"USD","delivery_days":1,"delivery_date":"2020-06-01T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_2b140da0c45a4952ad42883edc0425ef"},{"id":"rate_bf0034d28f4940a0a3459831189a3b56","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"75.35","currency":"USD","retail_rate":"73.13","retail_currency":"USD","list_rate":"73.67","list_currency":"USD","delivery_days":1,"delivery_date":"2020-06-01T08:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_2b140da0c45a4952ad42883edc0425ef"},{"id":"rate_33be4778bd0242ef86935bf69a03d6bf","object":"Rate","created_at":"2020-05-30T01:44:01Z","updated_at":"2020-05-30T01:44:01Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"44.90","currency":"USD","retail_rate":"42.68","retail_currency":"USD","list_rate":"43.22","list_currency":"USD","delivery_days":1,"delivery_date":"2020-06-01T10:30:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9281f508c3af4580b2f5d511f2124ee8","carrier_account_id":"ca_2b140da0c45a4952ad42883edc0425ef"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_b4488ab46d884d3e9ad870df3c44359c","object":"Address","created_at":"2020-05-30T01:43:58Z","updated_at":"2020-05-30T01:43:58Z","name":"Dr.
+      Steve Brule","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
+      Beach","state":"CA","zip":"90277","country":"US","phone":"8573875756","email":"dr_steve_brule@gmail.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_174f863f759943b48b8c2580fd6ea48e","object":"Address","created_at":"2020-05-30T01:43:58Z","updated_at":"2020-05-30T01:43:58Z","name":"Dr.
+      Steve Brule","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
+      Beach","state":"CA","zip":"90277","country":"US","phone":"8573875756","email":"dr_steve_brule@gmail.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_b4488ab46d884d3e9ad870df3c44359c","object":"Address","created_at":"2020-05-30T01:43:58Z","updated_at":"2020-05-30T01:43:58Z","name":"Dr.
+      Steve Brule","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
+      Beach","state":"CA","zip":"90277","country":"US","phone":"8573875756","email":"dr_steve_brule@gmail.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_9281f508c3af4580b2f5d511f2124ee8","object":"Shipment"}],"has_more":false}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 9976c79a5ed1e7dcfb2fed3d0002b126
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb4sj
+      X-Proxied:
+      - intlb2sj 5834894b53
+      - intlb2wdc 5834894b53
+      - extlb2wdc 5834894b53
+      X-Runtime:
+      - "0.119835"
+      X-Version-Label:
+      - easypost-202005292109-608e5794d4-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/tracker.go
+++ b/tracker.go
@@ -164,13 +164,13 @@ func (c *Client) CreateTrackerListWithContext(ctx context.Context, opts ...*Crea
 // ListTrackersOptions is used to specify query parameters for listing Tracker
 // objects.
 type ListTrackersOptions struct {
-	BeforeID      string     `json:"before_id,omitempty"`
-	AfterID       string     `json:"after_id,omitempty"`
-	StartDateTime *time.Time `json:"start_datetime,omitempty"`
-	EndDateTime   *time.Time `json:"end_datetime,omitempty"`
-	PageSize      int        `json:"page_size,omitempty"`
-	TrackingCodes []string   `json:"tracking_codes,omitempty"`
-	Carrier       string     `json:"carrier,omitempty"`
+	BeforeID      string     `url:"before_id,omitempty"`
+	AfterID       string     `url:"after_id,omitempty"`
+	StartDateTime *time.Time `url:"start_datetime,omitempty"`
+	EndDateTime   *time.Time `url:"end_datetime,omitempty"`
+	PageSize      int        `url:"page_size,omitempty"`
+	TrackingCodes []string   `url:"tracking_codes,omitempty"`
+	Carrier       string     `url:"carrier,omitempty"`
 }
 
 // ListTrackersResult holds the results from the list trackers API.
@@ -185,14 +185,13 @@ type ListTrackersResult struct {
 
 // ListTrackers provides a paginated result of Tracker objects.
 func (c *Client) ListTrackers(opts *ListTrackersOptions) (out *ListTrackersResult, err error) {
-	err = c.do(nil, http.MethodGet, "trackers", &opts, &out)
-	return
+	return c.ListTrackersWithContext(nil, opts)
 }
 
 // ListTrackersWithContext performs the same operation as ListTrackers, but
 // allows specifying a context that can interrupt the request.
 func (c *Client) ListTrackersWithContext(ctx context.Context, opts *ListTrackersOptions) (out *ListTrackersResult, err error) {
-	err = c.do(ctx, http.MethodGet, "trackers", &opts, &out)
+	err = c.do(ctx, http.MethodGet, "trackers", c.convertOptsToURLValues(opts), &out)
 	return
 }
 
@@ -209,15 +208,14 @@ type ListTrackersUpdatedOptions struct {
 
 // ListTrackersUpdated returns trackers with updated data.
 func (c *Client) ListTrackersUpdated(opts *ListTrackersUpdatedOptions) (out *ListTrackersResult, err error) {
-	err = c.do(nil, http.MethodGet, "trackers/all_updated", &opts, &out)
-	return
+	return c.ListTrackersUpdatedWithContext(nil, opts)
 }
 
 // ListTrackersUpdatedWithContext performs the same operation as
 // ListTrackersUpdated, but allows specifying a context that can interrupt the
 // request.
 func (c *Client) ListTrackersUpdatedWithContext(ctx context.Context, opts *ListTrackersUpdatedOptions) (out *ListTrackersResult, err error) {
-	err = c.do(ctx, http.MethodGet, "trackers/all_updated", &opts, &out)
+	err = c.do(ctx, http.MethodGet, "trackers/all_updated", c.convertOptsToURLValues(opts), &out)
 	return
 }
 

--- a/util.go
+++ b/util.go
@@ -5,7 +5,7 @@ func StringPtr(s string) *string {
 	return &s
 }
 
-// StringPtr returns a pointer to a bool with the given value.
+// BoolPtr returns a pointer to a bool with the given value.
 func BoolPtr(b bool) *bool {
 	return &b
 }

--- a/util.go
+++ b/util.go
@@ -4,3 +4,8 @@ package easypost
 func StringPtr(s string) *string {
 	return &s
 }
+
+// StringPtr returns a pointer to a bool with the given value.
+func BoolPtr(b bool) *bool {
+	return &b
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package easypost
 
-const Version = "1.0.2"
+const Version = "1.0.3"


### PR DESCRIPTION
This change fixes the bug in forming of GET HTTP requests to fetch a list of objects with query params. 
- the bool query params set to `false` were ignored
- the query params were sent as `application/json` content-type in a GET request rather than the HTTP standard of `application/x-www-form-urlencoded`

The well established `github.com/google/go-querystring/query` pkg was added to simplify the implementation of this change.

A simple test has been added in `shipment_test.go` to verify this change.