### PR TITLE
Removed unpaginated endpoints

### DIFF
--- a/customs.go
+++ b/customs.go
@@ -2,7 +2,6 @@ package easypost
 
 import (
 	"context"
-	"net/http"
 	"time"
 )
 
@@ -80,19 +79,6 @@ func (c *Client) CreateCustomsInfoWithContext(ctx context.Context, in *CustomsIn
 	return
 }
 
-// ListCustomsInfos provides a paginated result of CustomsInfo objects.
-func (c *Client) ListCustomsInfos() (out []*CustomsInfo, err error) {
-	err = c.do(nil, http.MethodGet, "customs_infos", nil, &out)
-	return
-}
-
-// ListCustomsInfosWithContext performs the same operation as ListCustomsInfos,
-// but allows specifying a context that can interrupt the request.
-func (c *Client) ListCustomsInfosWithContext(ctx context.Context) (out []*CustomsInfo, err error) {
-	err = c.do(ctx, http.MethodGet, "customs_infos", nil, &out)
-	return
-}
-
 // GetCustomsInfo returns the CustomsInfo object with the given ID or reference.
 func (c *Client) GetCustomsInfo(customsInfoID string) (out *CustomsInfo, err error) {
 	err = c.get(nil, "customs_infos/"+customsInfoID, &out)
@@ -134,19 +120,6 @@ func (c *Client) CreateCustomsItem(in *CustomsItem) (out *CustomsItem, err error
 func (c *Client) CreateCustomsItemWithContext(ctx context.Context, in *CustomsItem) (out *CustomsItem, err error) {
 	req := &createCustomsItemRequest{CustomsItem: in}
 	err = c.post(ctx, "customs_items", req, &out)
-	return
-}
-
-// ListCustomsItems provides a paginated result of CustomsItem objects.
-func (c *Client) ListCustomsItems() (out []*CustomsItem, err error) {
-	err = c.do(nil, http.MethodGet, "customs_items", nil, &out)
-	return
-}
-
-// ListCustomsItemsWithContext performs the same operation as ListCustomsItems,
-// but allows specifying a context that can interrupt the request.
-func (c *Client) ListCustomsItemsWithContext(ctx context.Context) (out []*CustomsItem, err error) {
-	err = c.do(ctx, http.MethodGet, "customs_items", nil, &out)
 	return
 }
 

--- a/order.go
+++ b/order.go
@@ -2,7 +2,6 @@ package easypost
 
 import (
 	"context"
-	"net/http"
 	"net/url"
 	"time"
 )
@@ -72,19 +71,6 @@ func (c *Client) CreateOrderWithContext(ctx context.Context, in *Order, accounts
 	var req createOrderRequest
 	req.Order.Order, req.Order.CarrierAccounts = in, accounts
 	err = c.post(ctx, "orders", &req, &out)
-	return
-}
-
-// ListOrders provides a paginated result of Order objects.
-func (c *Client) ListOrders() (out []*Order, err error) {
-	err = c.do(nil, http.MethodGet, "orders", nil, &out)
-	return
-}
-
-// ListOrdersWithContext performs the same operation as ListOrders,
-// but allows specifying a context that can interrupt the request.
-func (c *Client) ListOrdersWithContext(ctx context.Context) (out []*Order, err error) {
-	err = c.do(ctx, http.MethodGet, "orders", nil, &out)
 	return
 }
 

--- a/pickup.go
+++ b/pickup.go
@@ -2,7 +2,6 @@ package easypost
 
 import (
 	"context"
-	"net/http"
 	"net/url"
 	"time"
 )
@@ -71,19 +70,6 @@ func (c *Client) CreatePickup(in *Pickup) (out *Pickup, err error) {
 // allows specifying a context that can interrupt the request.
 func (c *Client) CreatePickupWithContext(ctx context.Context, in *Pickup) (out *Pickup, err error) {
 	err = c.post(ctx, "pickups", &createPickupRequest{Pickup: in}, &out)
-	return
-}
-
-// ListPickups provides a paginated result of Pickup objects.
-func (c *Client) ListPickups() (out []*Pickup, err error) {
-	err = c.do(nil, http.MethodGet, "pickups", nil, &out)
-	return
-}
-
-// ListPickupsWithContext performs the same operation as ListPickups,
-// but allows specifying a context that can interrupt the request.
-func (c *Client) ListPickupsWithContext(ctx context.Context) (out []*Pickup, err error) {
-	err = c.do(ctx, http.MethodGet, "pickups", nil, &out)
 	return
 }
 


### PR DESCRIPTION
Removing unpaginated endpoints from the client library due to low usage and performance.

The `net/http` import isn't used on these files, also removed those.