### PR TITLE
Change 'GetBatchScanForms' to be 'CreateBatchScanForms'

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -184,18 +184,18 @@ func (c *Client) GetBatchLabelsWithContext(ctx context.Context, batchID, format 
 	return
 }
 
-// GetBatchScanForms generates a scan form for the batch.
-func (c *Client) GetBatchScanForms(batchID, format string) (out *Batch, err error) {
+// CreateBatchScanForms generates a scan form for the batch.
+func (c *Client) CreateBatchScanForms(batchID, format string) (out *Batch, err error) {
 	vals := url.Values{"file_format": []string{format}}
-	err = c.do(nil, http.MethodGet, "batches/"+batchID+"/scan_form", vals, &out)
+	err = c.do(nil, http.MethodPost, "batches/"+batchID+"/scan_form", vals, &out)
 	return
 }
 
-// GetBatchScanFormsWithContext performs the same operation as
-// GetBatchScanForms, but allows specifying a context that can interrupt the
+// CreateBatchScanFormsWithContext performs the same operation as
+// CreateBatchScanForms, but allows specifying a context that can interrupt the
 // request.
-func (c *Client) GetBatchScanFormsWithContext(ctx context.Context, batchID, format string) (out *Batch, err error) {
+func (c *Client) CreateBatchScanFormsWithContext(ctx context.Context, batchID, format string) (out *Batch, err error) {
 	vals := url.Values{"file_format": []string{format}}
-	err = c.do(ctx, http.MethodGet, "batches/"+batchID+"/scan_form", vals, &out)
+	err = c.do(ctx, http.MethodPost, "batches/"+batchID+"/scan_form", vals, &out)
 	return
 }

--- a/examples/batches/scan_form_batch/scan_form_batch.go
+++ b/examples/batches/scan_form_batch/scan_form_batch.go
@@ -16,13 +16,13 @@ func main() {
     }
     client := easypost.New(apiKey)
 
-    // ScanForm Batch
+    // Create a ScanForm for a Batch
     batch, err := client.CreateBatchScanForms(
         "batch_12345",
         "string",
     )
     if err != nil {
-        fmt.Fprintln(os.Stderr, "error creating batch:", err)
+        fmt.Fprintln(os.Stderr, "error creating ScanForm for Batch:", err)
         os.Exit(1)
         return
     }

--- a/examples/batches/scan_form_batch/scan_form_batch.go
+++ b/examples/batches/scan_form_batch/scan_form_batch.go
@@ -3,9 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-
 	"github.com/EasyPost/easypost-go"
+	"os"
 )
 
 func main() {
@@ -20,6 +19,7 @@ func main() {
 	// Create a ScanForm for a Batch
 	batch, err := client.CreateBatchScanForms(
 		"batch_12345",
+		"string",
 	)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating ScanForm for Batch:", err)

--- a/examples/batches/scan_form_batch/scan_form_batch.go
+++ b/examples/batches/scan_form_batch/scan_form_batch.go
@@ -1,37 +1,37 @@
 package main
 
 import (
-    "encoding/json"
-    "fmt"
-    "github.com/EasyPost/easypost-go"
-    "os"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/EasyPost/easypost-go"
 )
 
 func main() {
-    apiKey := os.Getenv("EASYPOST_API_KEY")
-    if apiKey == "" {
-        fmt.Fprintln(os.Stderr, "missing API key")
-        os.Exit(1)
-        return
-    }
-    client := easypost.New(apiKey)
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
 
-    // Create a ScanForm for a Batch
-    batch, err := client.CreateBatchScanForms(
-        "batch_12345",
-        "string",
-    )
-    if err != nil {
-        fmt.Fprintln(os.Stderr, "error creating ScanForm for Batch:", err)
-        os.Exit(1)
-        return
-    }
+	// Create a ScanForm for a Batch
+	batch, err := client.CreateBatchScanForms(
+		"batch_12345",
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating ScanForm for Batch:", err)
+		os.Exit(1)
+		return
+	}
 
-    prettyJSON, err := json.MarshalIndent(batch, "", "    ")
-    if err != nil {
-        fmt.Fprintln(os.Stderr, "error creating JSON:", err)
-        os.Exit(1)
-        return
-    }
-    fmt.Println(string(prettyJSON))
+	prettyJSON, err := json.MarshalIndent(batch, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+		os.Exit(1)
+		return
+	}
+	fmt.Println(string(prettyJSON))
 }

--- a/examples/batches/scan_form_batch/scan_form_batch.go
+++ b/examples/batches/scan_form_batch/scan_form_batch.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "github.com/EasyPost/easypost-go"
+    "os"
+)
+
+func main() {
+    apiKey := os.Getenv("EASYPOST_API_KEY")
+    if apiKey == "" {
+        fmt.Fprintln(os.Stderr, "missing API key")
+        os.Exit(1)
+        return
+    }
+    client := easypost.New(apiKey)
+
+    // ScanForm Batch
+    batch, err := client.CreateBatchScanForms(
+        "batch_12345",
+        "string",
+    )
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "error creating batch:", err)
+        os.Exit(1)
+        return
+    }
+
+    prettyJSON, err := json.MarshalIndent(batch, "", "    ")
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+        os.Exit(1)
+        return
+    }
+    fmt.Println(string(prettyJSON))
+}

--- a/examples/batches/scan_form_batch/scan_form_batch.go
+++ b/examples/batches/scan_form_batch/scan_form_batch.go
@@ -18,8 +18,8 @@ func main() {
 
 	// Create a ScanForm for a Batch
 	batch, err := client.CreateBatchScanForms(
-		"batch_12345",
-		"string",
+		"batch_123",
+		"batch_456",
 	)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating ScanForm for Batch:", err)


### PR DESCRIPTION
This PR is intended to solve issue #11 raised by Justin Hammond.

Per EasyPost API Docs for creating a scan_form from a Batch object, the method should be a POST and not a GET.

docs link: https://www.easypost.com/docs/api#manifesting-scan-form

Rather than making a new method, I modified this existing method as I believe it was originally intended to do the thing we want to do.

`// GetBatchScanForms generates a scan form for the batch.`

I tested this method and indeed it failed as a GET request, as expected based on the API docs. Changing the method to a POST request resulted in successfully creating a scan_form using a batch id. 

renamed both methods `GetBatchScanForms` and `GetBatchScanFormsWithContext`
to be `CreateBatchScanForms` and `CreateBatchScanFormsWithContext` to follow established naming conventions.
