### PR TITLE
feat: adds smartrate functionality

### DIFF
--- a/rate.go
+++ b/rate.go
@@ -7,30 +7,36 @@ import (
 
 // A Rate contains information on shipping cost and delivery time.
 type Rate struct {
-	ID                     string     `json:"id,omitempty"`
-	Object                 string     `json:"object,omitempty"`
-	Mode                   string     `json:"mode,omitempty"`
-	CreatedAt              *time.Time `json:"created_at,omitempty"`
-	UpdatedAt              *time.Time `json:"updated_at,omitempty"`
-	Service                string     `json:"service,omitempty"`
-	Carrier                string     `json:"carrier,omitempty"`
-	CarrierAccountID       string     `json:"carrier_account_id,omitempty"`
-	ShipmentID             string     `json:"shipment_id,omitempty"`
-	Rate                   string     `json:"rate,omitempty"`
-	Currency               string     `json:"currency,omitempty"`
-	RetailRate             string     `json:"retail_rate,omitempty"`
-	RetailCurrency         string     `json:"retail_currency,omitempty"`
-	ListRate               string     `json:"list_rate,omitempty"`
-	ListCurrency           string     `json:"list_currency,omitempty"`
-	DeliveryDays           int        `json:"delivery_days,omitempty"`
-	DeliveryDate           *time.Time `json:"delivery_date,omitempty"`
-	DeliveryDateGuaranteed bool       `json:"delivery_date_guaranteed,omitempty"`
-	EstDeliveryDays        int        `json:"est_delivery_dats,omitempty"`
+	ID                     string         `json:"id,omitempty"`
+	Object                 string         `json:"object,omitempty"`
+	Mode                   string         `json:"mode,omitempty"`
+	CreatedAt              *time.Time     `json:"created_at,omitempty"`
+	UpdatedAt              *time.Time     `json:"updated_at,omitempty"`
+	Service                string         `json:"service,omitempty"`
+	Carrier                string         `json:"carrier,omitempty"`
+	CarrierAccountID       string         `json:"carrier_account_id,omitempty"`
+	ShipmentID             string         `json:"shipment_id,omitempty"`
+	Rate                   string         `json:"rate,omitempty"`
+	Currency               string         `json:"currency,omitempty"`
+	RetailRate             string         `json:"retail_rate,omitempty"`
+	RetailCurrency         string         `json:"retail_currency,omitempty"`
+	ListRate               string         `json:"list_rate,omitempty"`
+	ListCurrency           string         `json:"list_currency,omitempty"`
+	DeliveryDays           int            `json:"delivery_days,omitempty"`
+	DeliveryDate           *time.Time     `json:"delivery_date,omitempty"`
+	DeliveryDateGuaranteed bool           `json:"delivery_date_guaranteed,omitempty"`
+	EstDeliveryDays        int            `json:"est_delivery_dats,omitempty"`
+	TimeInTransit          *TimeInTransit `json:"time_in_transit,omitemtpy"`
 }
 
-type Smartrate struct {
-	Rate
-	TimeInTransit map[string]interface{} `json:"time_in_transit,omitempty"`
+type TimeInTransit struct {
+	Percentile50 int `json:"percentile_50,omitempty"`
+	Percentile75 int `json:"percentile_75,omitempty"`
+	Percentile85 int `json:"percentile_85,omitempty"`
+	Percentile90 int `json:"percentile_90,omitempty"`
+	Percentile95 int `json:"percentile_95,omitempty"`
+	Percentile97 int `json:"percentile_97,omitempty"`
+	Percentile99 int `json:"percentile_99,omitempty"`
 }
 
 // GetRate retrieves a previously-created rate by its ID.
@@ -43,24 +49,5 @@ func (c *Client) GetRate(rateID string) (out *Rate, err error) {
 // specifying a context that can interrupt the request.
 func (c *Client) GetRateWithContext(ctx context.Context, rateID string) (out *Rate, err error) {
 	err = c.get(ctx, "rates/"+rateID, &out)
-	return
-}
-
-type getShipmentSmartratesResponse struct {
-	Smartrate *[]*Smartrate `json:"result,omitempty"`
-}
-
-// GetShipmentSmartrates fetches the available smartrates for a shipment.
-func (c *Client) GetShipmentSmartrates(shipmentID string) (out []*Smartrate, err error) {
-	res := &getShipmentSmartratesResponse{Smartrate: &out}
-	err = c.get(nil, "shipments/"+shipmentID+"/smartrate", &res)
-	return
-}
-
-// GetShipmentSmartratesWithContext performs the same operation as GetShipmentRates,
-// but allows specifying a context that can interrupt the request.
-func (c *Client) GetShipmentSmartratesWithContext(ctx context.Context, shipmentID string) (out []*Smartrate, err error) {
-	res := &getShipmentSmartratesResponse{Smartrate: &out}
-	err = c.get(ctx, "shipments/"+shipmentID+"/smartrate", &res)
 	return
 }

--- a/rate.go
+++ b/rate.go
@@ -28,6 +28,11 @@ type Rate struct {
 	EstDeliveryDays        int        `json:"est_delivery_dats,omitempty"`
 }
 
+type Smartrate struct {
+	Rate
+	TimeInTransit map[string]interface{} `json:"time_in_transit,omitempty"`
+}
+
 // GetRate retrieves a previously-created rate by its ID.
 func (c *Client) GetRate(rateID string) (out *Rate, err error) {
 	err = c.get(nil, "rates/"+rateID, &out)
@@ -38,5 +43,24 @@ func (c *Client) GetRate(rateID string) (out *Rate, err error) {
 // specifying a context that can interrupt the request.
 func (c *Client) GetRateWithContext(ctx context.Context, rateID string) (out *Rate, err error) {
 	err = c.get(ctx, "rates/"+rateID, &out)
+	return
+}
+
+type getShipmentSmartratesResponse struct {
+	Smartrate *[]*Smartrate `json:"result,omitempty"`
+}
+
+// GetShipmentSmartrates fetches the available smartrates for a shipment.
+func (c *Client) GetShipmentSmartrates(shipmentID string) (out []*Smartrate, err error) {
+	res := &getShipmentSmartratesResponse{Smartrate: &out}
+	err = c.get(nil, "shipments/"+shipmentID+"/smartrate", &res)
+	return
+}
+
+// GetShipmentSmartratesWithContext performs the same operation as GetShipmentRates,
+// but allows specifying a context that can interrupt the request.
+func (c *Client) GetShipmentSmartratesWithContext(ctx context.Context, shipmentID string) (out []*Smartrate, err error) {
+	res := &getShipmentSmartratesResponse{Smartrate: &out}
+	err = c.get(ctx, "shipments/"+shipmentID+"/smartrate", &res)
 	return
 }

--- a/shipment.go
+++ b/shipment.go
@@ -290,21 +290,17 @@ func (c *Client) GetShipmentRatesWithContext(ctx context.Context, shipmentID str
 	return
 }
 
-type getShipmentSmartratesResponse struct {
-	Smartrates *[]*Rate `json:"result,omitempty"`
-}
-
 // GetShipmentSmartrates fetches the available smartrates for a shipment.
 func (c *Client) GetShipmentSmartrates(shipmentID string) (out []*Rate, err error) {
-	res := &getShipmentSmartratesResponse{Smartrates: &out}
-	err = c.get(nil, "shipments/"+shipmentID+"/smartrate", &res)
-	return
+	return c.GetShipmentSmartratesWithContext(nil, shipmentID)
 }
 
 // GetShipmentSmartratesWithContext performs the same operation as GetShipmentRates,
 // but allows specifying a context that can interrupt the request.
 func (c *Client) GetShipmentSmartratesWithContext(ctx context.Context, shipmentID string) (out []*Rate, err error) {
-	res := &getShipmentSmartratesResponse{Smartrates: &out}
+	res := struct {
+		Smartrates *[]*Rate `json:"result,omitempty"`
+	}{Smartrates: &out}
 	err = c.get(ctx, "shipments/"+shipmentID+"/smartrate", &res)
 	return
 }

--- a/shipment.go
+++ b/shipment.go
@@ -290,6 +290,25 @@ func (c *Client) GetShipmentRatesWithContext(ctx context.Context, shipmentID str
 	return
 }
 
+type getShipmentSmartratesResponse struct {
+	Smartrates *[]*Rate `json:"result,omitempty"`
+}
+
+// GetShipmentSmartrates fetches the available smartrates for a shipment.
+func (c *Client) GetShipmentSmartrates(shipmentID string) (out []*Rate, err error) {
+	res := &getShipmentSmartratesResponse{Smartrates: &out}
+	err = c.get(nil, "shipments/"+shipmentID+"/smartrate", &res)
+	return
+}
+
+// GetShipmentSmartratesWithContext performs the same operation as GetShipmentRates,
+// but allows specifying a context that can interrupt the request.
+func (c *Client) GetShipmentSmartratesWithContext(ctx context.Context, shipmentID string) (out []*Rate, err error) {
+	res := &getShipmentSmartratesResponse{Smartrates: &out}
+	err = c.get(ctx, "shipments/"+shipmentID+"/smartrate", &res)
+	return
+}
+
 // InsureShipment purchases insurance for the shipment. Insurance should be
 // purchased after purchasing the shipment, but before it has been processed by
 // the carrier. On success, the purchased insurance will be reflected in the

--- a/tests/shipment_test.go
+++ b/tests/shipment_test.go
@@ -216,11 +216,11 @@ func (c *ClientTests) TestShipmentSmartrates() {
 
 	smartrates, err := client.GetShipmentSmartrates(shipment.ID)
 	assert.Equal(shipment.Rates[0].ID, smartrates[0].ID)
-	assert.Equal(smartrates[0].TimeInTransit["percentile_50"], float64(1))
-	assert.Equal(smartrates[0].TimeInTransit["percentile_75"], float64(2))
-	assert.Equal(smartrates[0].TimeInTransit["percentile_85"], float64(2))
-	assert.Equal(smartrates[0].TimeInTransit["percentile_90"], float64(3))
-	assert.Equal(smartrates[0].TimeInTransit["percentile_95"], float64(3))
-	assert.Equal(smartrates[0].TimeInTransit["percentile_97"], float64(4))
-	assert.Equal(smartrates[0].TimeInTransit["percentile_99"], float64(5))
+	assert.Equal(smartrates[0].TimeInTransit.Percentile50, 1)
+	assert.Equal(smartrates[0].TimeInTransit.Percentile75, 2)
+	assert.Equal(smartrates[0].TimeInTransit.Percentile85, 2)
+	assert.Equal(smartrates[0].TimeInTransit.Percentile90, 3)
+	assert.Equal(smartrates[0].TimeInTransit.Percentile95, 3)
+	assert.Equal(smartrates[0].TimeInTransit.Percentile97, 4)
+	assert.Equal(smartrates[0].TimeInTransit.Percentile99, 5)
 }

--- a/tests/testdata/TestClient/TestShipmentSmartrates.yaml
+++ b/tests/testdata/TestClient/TestShipmentSmartrates.yaml
@@ -1,0 +1,301 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"address":{"street1":"179 N Harbor Dr","city":"Redondo Beach","state":"CA","zip":"90277","country":"US","name":"Elmer
+      Fudd","phone":"613-555-1212"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
+    url: https://api.easypost.com/v2/addresses
+    method: POST
+  response:
+    body: '{"id":"adr_6521e48856b844f3b69cbc38d251e207","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":"Elmer
+      Fudd","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
+      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"bfddc8284337a301c8dc171371ddb1ba"
+      Expires:
+      - "0"
+      Location:
+      - /api/v2/addresses/adr_6521e48856b844f3b69cbc38d251e207
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - c2b10e7960a82426e78755620159f0e8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb6nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 7ba176609e
+      - extlb1nuq 15c8815ace
+      X-Request-Id:
+      - 4ea1176e-c379-4a62-bb3e-3a49645c768a
+      X-Runtime:
+      - "0.030660"
+      X-Version-Label:
+      - easypost-202105212044-9f976cba01-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"address":{"street1":"One Montgomery St","street2":"Ste 400","city":"San
+      Francisco","state":"CA","zip":"94104","company":"EasyPost","phone":"415-456-7890"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
+    url: https://api.easypost.com/v2/addresses
+    method: POST
+  response:
+    body: '{"id":"adr_8a9ec7ca5277481d892654e1bb26acf7","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":null,"company":"EasyPost","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"79056384a7ee132a831d2479425b13e1"
+      Expires:
+      - "0"
+      Location:
+      - /api/v2/addresses/adr_8a9ec7ca5277481d892654e1bb26acf7
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - c2b10e7960a82426e78755620159f0f1
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb8nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 7ba176609e
+      - extlb1nuq 15c8815ace
+      X-Request-Id:
+      - 1da41bdd-fd63-4bee-bdb9-9230ce1b7dcb
+      X-Runtime:
+      - "0.028210"
+      X-Version-Label:
+      - easypost-202105212044-9f976cba01-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"parcel":{"length":10.2,"width":7.8,"height":4.3,"weight":21.2}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
+    url: https://api.easypost.com/v2/parcels
+    method: POST
+  response:
+    body: '{"id":"prcl_675a7e0da6744ebc825c29f2bce3f0a5","object":"Parcel","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"cdf0c5893750e8257633c2a73d512bd4"
+      Expires:
+      - "0"
+      Location:
+      - /api/v2/parcels.prcl_675a7e0da6744ebc825c29f2bce3f0a5
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - c2b10e7960a82426e78755620159f0fb
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb7nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 7ba176609e
+      - extlb1nuq 15c8815ace
+      X-Request-Id:
+      - 44e04075-2336-46c2-b154-3dd88de00431
+      X-Runtime:
+      - "0.027455"
+      X-Version-Label:
+      - easypost-202105212044-9f976cba01-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"shipment":{"to_address":{"id":"adr_6521e48856b844f3b69cbc38d251e207","object":"Address","mode":"test","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","street1":"179
+      N Harbor Dr","city":"Redondo Beach","state":"CA","zip":"90277","country":"US","name":"Elmer
+      Fudd","phone":"6135551212","verifications":{"zip4":null,"delivery":null}},"from_address":{"id":"adr_8a9ec7ca5277481d892654e1bb26acf7","object":"Address","mode":"test","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"4154567890","verifications":{"zip4":null,"delivery":null}},"parcel":{"id":"prcl_675a7e0da6744ebc825c29f2bce3f0a5","object":"Parcel","mode":"test","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","length":10.2,"width":7.8,"height":4.3,"weight":21.2}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
+    url: https://api.easypost.com/v2/shipments
+    method: POST
+  response:
+    body: '{"created_at":"2021-05-21T21:20:38Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable
+      to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-05-21T21:20:40Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_8a9ec7ca5277481d892654e1bb26acf7","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":null,"company":"EasyPost","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_675a7e0da6744ebc825c29f2bce3f0a5","object":"Parcel","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_c93998aa4f274a609690375f55448d09","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"Express","carrier":"USPS","rate":"32.10","currency":"USD","retail_rate":"36.90","retail_currency":"USD","list_rate":"32.10","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_c40d303213564cbdb77b63c345a79c11","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"Priority","carrier":"USPS","rate":"8.24","currency":"USD","retail_rate":"10.10","retail_currency":"USD","list_rate":"8.24","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_a7da01a0d09b42d8987740bb8d3da86d","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"8.04","currency":"USD","retail_rate":"8.04","retail_currency":"USD","list_rate":"8.04","list_currency":"USD","delivery_days":5,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":5,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_5aa2e8153f8942e6b6f330d9b404f16a","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"17.44","currency":"USD","retail_rate":"17.44","retail_currency":"USD","list_rate":"18.41","list_currency":"USD","delivery_days":3,"delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_595a1bcabc904e23ab30fe8cefdb45d4","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"100.84","currency":"USD","retail_rate":"100.84","retail_currency":"USD","list_rate":"108.81","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-24T08:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_0309da9a53e14e3f8244d1df6bae2665","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"2ndDayAirAM","carrier":"UPS","rate":"25.90","currency":"USD","retail_rate":"25.90","retail_currency":"USD","list_rate":"26.73","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_dca170fe4f5c44a6a37575728be7d16e","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"Ground","carrier":"UPS","rate":"12.53","currency":"USD","retail_rate":"12.53","retail_currency":"USD","list_rate":"12.05","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_9cdae807c79f4a7a9614ecc0520b9952","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"64.70","currency":"USD","retail_rate":"64.70","retail_currency":"USD","list_rate":"71.42","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-24T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_6fdf0b6c5469409dac029928b1ceaba9","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"68.74","currency":"USD","retail_rate":"68.74","retail_currency":"USD","list_rate":"76.71","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-24T10:30:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_793f12d8c4e24a2e982ddfea1791c248","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"22.88","currency":"USD","retail_rate":"22.88","retail_currency":"USD","list_rate":"24.70","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_6521e48856b844f3b69cbc38d251e207","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":"Elmer
+      Fudd","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
+      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":4,"return_address":{"id":"adr_8a9ec7ca5277481d892654e1bb26acf7","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":null,"company":"EasyPost","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6521e48856b844f3b69cbc38d251e207","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":"Elmer
+      Fudd","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
+      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_e9928c6434d54e23ba232afa8c745305","object":"Shipment"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"95fd8bf66179e29333564a9fdf2ee4d2"
+      Expires:
+      - "0"
+      Location:
+      - /api/v2/shipments/shp_e9928c6434d54e23ba232afa8c745305
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - c2b10e7960a82426e78755620159f100
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb8nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 7ba176609e
+      - extlb1nuq 15c8815ace
+      X-Request-Id:
+      - 0c7cecbb-59ce-4572-a2cc-8bfe2a5de76b
+      X-Runtime:
+      - "1.472116"
+      X-Version-Label:
+      - easypost-202105212044-9f976cba01-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
+    url: https://api.easypost.com/v2/shipments/shp_e9928c6434d54e23ba232afa8c745305/smartrate
+    method: GET
+  response:
+    body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_c93998aa4f274a609690375f55448d09","list_currency":"USD","list_rate":32.1,"mode":"test","object":"Rate","rate":32.1,"retail_currency":"USD","retail_rate":36.9,"service":"Express","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":2,"percentile_90":3,"percentile_95":3,"percentile_97":4,"percentile_99":5},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_c40d303213564cbdb77b63c345a79c11","list_currency":"USD","list_rate":8.24,"mode":"test","object":"Rate","rate":8.24,"retail_currency":"USD","retail_rate":10.1,"service":"Priority","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":3,"percentile_97":3,"percentile_99":4},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":5,"est_delivery_days":5,"id":"rate_a7da01a0d09b42d8987740bb8d3da86d","list_currency":"USD","list_rate":8.04,"mode":"test","object":"Rate","rate":8.04,"retail_currency":"USD","retail_rate":8.04,"service":"ParcelSelect","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":5,"percentile_95":8,"percentile_97":9,"percentile_99":14},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":3,"est_delivery_days":3,"id":"rate_5aa2e8153f8942e6b6f330d9b404f16a","list_currency":"USD","list_rate":18.41,"mode":"test","object":"Rate","rate":17.44,"retail_currency":"USD","retail_rate":17.44,"service":"3DaySelect","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":3,"percentile_95":3,"percentile_97":3,"percentile_99":3},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-24T08:00:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_595a1bcabc904e23ab30fe8cefdb45d4","list_currency":"USD","list_rate":108.81,"mode":"test","object":"Rate","rate":100.84,"retail_currency":"USD","retail_rate":100.84,"service":"NextDayAirEarlyAM","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":null,"percentile_75":null,"percentile_85":null,"percentile_90":null,"percentile_95":null,"percentile_97":null,"percentile_99":null},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_0309da9a53e14e3f8244d1df6bae2665","list_currency":"USD","list_rate":26.73,"mode":"test","object":"Rate","rate":25.9,"retail_currency":"USD","retail_rate":25.9,"service":"2ndDayAirAM","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":null,"percentile_75":null,"percentile_85":null,"percentile_90":null,"percentile_95":null,"percentile_97":null,"percentile_99":null},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_dca170fe4f5c44a6a37575728be7d16e","list_currency":"USD","list_rate":12.05,"mode":"test","object":"Rate","rate":12.53,"retail_currency":"USD","retail_rate":12.53,"service":"Ground","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":3,"percentile_97":3,"percentile_99":3},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-24T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_9cdae807c79f4a7a9614ecc0520b9952","list_currency":"USD","list_rate":71.42,"mode":"test","object":"Rate","rate":64.7,"retail_currency":"USD","retail_rate":64.7,"service":"NextDayAirSaver","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":2},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-24T10:30:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_6fdf0b6c5469409dac029928b1ceaba9","list_currency":"USD","list_rate":76.71,"mode":"test","object":"Rate","rate":68.74,"retail_currency":"USD","retail_rate":68.74,"service":"NextDayAir","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":2},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_793f12d8c4e24a2e982ddfea1791c248","list_currency":"USD","list_rate":24.7,"mode":"test","object":"Rate","rate":22.88,"retail_currency":"USD","retail_rate":22.88,"service":"2ndDayAir","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2021-05-21T21:20:40Z"}]}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"5906be8a58deedfd5cf9fcfdd6180ed1"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - c2b10e7960a82428e78755620159f165
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb2nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 7ba176609e
+      - extlb1nuq 15c8815ace
+      X-Request-Id:
+      - a122a7bc-77fb-414b-a18d-77b840189ec8
+      X-Runtime:
+      - "0.096233"
+      X-Version-Label:
+      - easypost-202105212044-9f976cba01-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/tests/testdata/TestClient/TestShipmentSmartrates.yaml
+++ b/tests/testdata/TestClient/TestShipmentSmartrates.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.easypost.com/v2/addresses
     method: POST
   response:
-    body: '{"id":"adr_6521e48856b844f3b69cbc38d251e207","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":"Elmer
+    body: '{"id":"adr_d0c57484196644a09ac1ecd148b436f7","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":"Elmer
       Fudd","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
       Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
     headers:
@@ -22,11 +22,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"bfddc8284337a301c8dc171371ddb1ba"
+      - W/"f74ff8e8439797f37f429f933695e32e"
       Expires:
       - "0"
       Location:
-      - /api/v2/addresses/adr_6521e48856b844f3b69cbc38d251e207
+      - /api/v2/addresses/adr_d0c57484196644a09ac1ecd148b436f7
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -40,7 +40,7 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - c2b10e7960a82426e78755620159f0e8
+      - bc7536fa60abe7b5e786b39a0058197b
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
@@ -48,12 +48,12 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 7ba176609e
-      - extlb1nuq 15c8815ace
+      - intlb2nuq 7ba176609e
+      - extlb2nuq 15c8815ace
       X-Request-Id:
-      - 4ea1176e-c379-4a62-bb3e-3a49645c768a
+      - f995bed4-34d1-451f-bf93-6f05ab8b315c
       X-Runtime:
-      - "0.030660"
+      - "0.030231"
       X-Version-Label:
       - easypost-202105212044-9f976cba01-master
       X-Xss-Protection:
@@ -73,7 +73,7 @@ interactions:
     url: https://api.easypost.com/v2/addresses
     method: POST
   response:
-    body: '{"id":"adr_8a9ec7ca5277481d892654e1bb26acf7","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":null,"company":"EasyPost","street1":"One
+    body: '{"id":"adr_820db84392314aa0b6fe8c88a51d0f21","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":null,"company":"EasyPost","street1":"One
       Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
     headers:
       Cache-Control:
@@ -81,11 +81,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"79056384a7ee132a831d2479425b13e1"
+      - W/"05f4b8ced61679a6e7c2513b588e5a06"
       Expires:
       - "0"
       Location:
-      - /api/v2/addresses/adr_8a9ec7ca5277481d892654e1bb26acf7
+      - /api/v2/addresses/adr_820db84392314aa0b6fe8c88a51d0f21
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -99,20 +99,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - c2b10e7960a82426e78755620159f0f1
+      - bc7536fa60abe7b5e786b39a00581983
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb8nuq
+      - bigweb6nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
       - intlb2nuq 7ba176609e
-      - extlb1nuq 15c8815ace
+      - extlb2nuq 15c8815ace
       X-Request-Id:
-      - 1da41bdd-fd63-4bee-bdb9-9230ce1b7dcb
+      - f42fda42-11b3-4ccb-af74-f311997bf2cd
       X-Runtime:
-      - "0.028210"
+      - "0.029735"
       X-Version-Label:
       - easypost-202105212044-9f976cba01-master
       X-Xss-Protection:
@@ -131,18 +131,18 @@ interactions:
     url: https://api.easypost.com/v2/parcels
     method: POST
   response:
-    body: '{"id":"prcl_675a7e0da6744ebc825c29f2bce3f0a5","object":"Parcel","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"}'
+    body: '{"id":"prcl_5f1060fd51654936a0050d354211e5f1","object":"Parcel","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"cdf0c5893750e8257633c2a73d512bd4"
+      - W/"dd6880102ed5156e29e9d7b6abd41b30"
       Expires:
       - "0"
       Location:
-      - /api/v2/parcels.prcl_675a7e0da6744ebc825c29f2bce3f0a5
+      - /api/v2/parcels.prcl_5f1060fd51654936a0050d354211e5f1
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -151,27 +151,25 @@ interactions:
       - max-age=15768000; includeSubDomains; preload
       X-Backend:
       - easypost
-      X-Canary:
-      - direct
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - c2b10e7960a82426e78755620159f0fb
+      - bc7536fa60abe7b5e786b39a0058198a
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb7nuq
+      - bigweb2nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 7ba176609e
-      - extlb1nuq 15c8815ace
+      - intlb1nuq 7ba176609e
+      - extlb2nuq 15c8815ace
       X-Request-Id:
-      - 44e04075-2336-46c2-b154-3dd88de00431
+      - 1cf8f648-adf8-44d4-900c-7d1e34439c76
       X-Runtime:
-      - "0.027455"
+      - "0.062811"
       X-Version-Label:
       - easypost-202105212044-9f976cba01-master
       X-Xss-Protection:
@@ -180,10 +178,10 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"shipment":{"to_address":{"id":"adr_6521e48856b844f3b69cbc38d251e207","object":"Address","mode":"test","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","street1":"179
+    body: '{"shipment":{"to_address":{"id":"adr_d0c57484196644a09ac1ecd148b436f7","object":"Address","mode":"test","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","street1":"179
       N Harbor Dr","city":"Redondo Beach","state":"CA","zip":"90277","country":"US","name":"Elmer
-      Fudd","phone":"6135551212","verifications":{"zip4":null,"delivery":null}},"from_address":{"id":"adr_8a9ec7ca5277481d892654e1bb26acf7","object":"Address","mode":"test","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","street1":"One
-      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"4154567890","verifications":{"zip4":null,"delivery":null}},"parcel":{"id":"prcl_675a7e0da6744ebc825c29f2bce3f0a5","object":"Parcel","mode":"test","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","length":10.2,"width":7.8,"height":4.3,"weight":21.2}}}'
+      Fudd","phone":"6135551212","verifications":{"zip4":null,"delivery":null}},"from_address":{"id":"adr_820db84392314aa0b6fe8c88a51d0f21","object":"Address","mode":"test","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"4154567890","verifications":{"zip4":null,"delivery":null}},"parcel":{"id":"prcl_5f1060fd51654936a0050d354211e5f1","object":"Parcel","mode":"test","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","length":10.2,"width":7.8,"height":4.3,"weight":21.2}}}'
     form: {}
     headers:
       Content-Type:
@@ -193,25 +191,25 @@ interactions:
     url: https://api.easypost.com/v2/shipments
     method: POST
   response:
-    body: '{"created_at":"2021-05-21T21:20:38Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable
-      to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-05-21T21:20:40Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_8a9ec7ca5277481d892654e1bb26acf7","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":null,"company":"EasyPost","street1":"One
-      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_675a7e0da6744ebc825c29f2bce3f0a5","object":"Parcel","created_at":"2021-05-21T21:20:38Z","updated_at":"2021-05-21T21:20:38Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_c93998aa4f274a609690375f55448d09","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"Express","carrier":"USPS","rate":"32.10","currency":"USD","retail_rate":"36.90","retail_currency":"USD","list_rate":"32.10","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_c40d303213564cbdb77b63c345a79c11","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"Priority","carrier":"USPS","rate":"8.24","currency":"USD","retail_rate":"10.10","retail_currency":"USD","list_rate":"8.24","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_a7da01a0d09b42d8987740bb8d3da86d","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"8.04","currency":"USD","retail_rate":"8.04","retail_currency":"USD","list_rate":"8.04","list_currency":"USD","delivery_days":5,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":5,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_5aa2e8153f8942e6b6f330d9b404f16a","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"17.44","currency":"USD","retail_rate":"17.44","retail_currency":"USD","list_rate":"18.41","list_currency":"USD","delivery_days":3,"delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_595a1bcabc904e23ab30fe8cefdb45d4","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"100.84","currency":"USD","retail_rate":"100.84","retail_currency":"USD","list_rate":"108.81","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-24T08:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_0309da9a53e14e3f8244d1df6bae2665","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"2ndDayAirAM","carrier":"UPS","rate":"25.90","currency":"USD","retail_rate":"25.90","retail_currency":"USD","list_rate":"26.73","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_dca170fe4f5c44a6a37575728be7d16e","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"Ground","carrier":"UPS","rate":"12.53","currency":"USD","retail_rate":"12.53","retail_currency":"USD","list_rate":"12.05","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_9cdae807c79f4a7a9614ecc0520b9952","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"64.70","currency":"USD","retail_rate":"64.70","retail_currency":"USD","list_rate":"71.42","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-24T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_6fdf0b6c5469409dac029928b1ceaba9","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"68.74","currency":"USD","retail_rate":"68.74","retail_currency":"USD","list_rate":"76.71","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-24T10:30:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_793f12d8c4e24a2e982ddfea1791c248","object":"Rate","created_at":"2021-05-21T21:20:40Z","updated_at":"2021-05-21T21:20:40Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"22.88","currency":"USD","retail_rate":"22.88","retail_currency":"USD","list_rate":"24.70","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_6521e48856b844f3b69cbc38d251e207","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":"Elmer
+    body: '{"created_at":"2021-05-24T17:51:49Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable
+      to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-05-24T17:51:51Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_820db84392314aa0b6fe8c88a51d0f21","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":null,"company":"EasyPost","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_5f1060fd51654936a0050d354211e5f1","object":"Parcel","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_83f3141a48164e368889e364cc6c8874","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"Express","carrier":"USPS","rate":"32.10","currency":"USD","retail_rate":"36.90","retail_currency":"USD","list_rate":"32.10","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_ab87ffdaf18c4e7cbf9415d2f9206481","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"Priority","carrier":"USPS","rate":"8.24","currency":"USD","retail_rate":"10.10","retail_currency":"USD","list_rate":"8.24","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_49d50227310749d298468ae320246dc4","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"8.04","currency":"USD","retail_rate":"8.04","retail_currency":"USD","list_rate":"8.04","list_currency":"USD","delivery_days":5,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":5,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_a00964e2298547a3bc38568cc33cb8fa","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"17.48","currency":"USD","retail_rate":"17.48","retail_currency":"USD","list_rate":"18.46","list_currency":"USD","delivery_days":3,"delivery_date":"2021-05-27T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_a0b5aab8ca3f4acd9c5252c213f1169b","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"101.07","currency":"USD","retail_rate":"101.07","retail_currency":"USD","list_rate":"109.06","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-25T08:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_3b73d86f9c504939abc3d98663b214ec","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"2ndDayAirAM","carrier":"UPS","rate":"25.97","currency":"USD","retail_rate":"25.97","retail_currency":"USD","list_rate":"26.79","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_04b16abe30f34cbeb69410b5521ca781","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"Ground","carrier":"UPS","rate":"12.53","currency":"USD","retail_rate":"12.53","retail_currency":"USD","list_rate":"12.05","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_189ca4206a164ee4b7b45e23b8d378b2","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"64.85","currency":"USD","retail_rate":"64.85","retail_currency":"USD","list_rate":"71.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_59b2c10ba3e7462ea3d29b93d21fa6ae","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"68.90","currency":"USD","retail_rate":"68.90","retail_currency":"USD","list_rate":"76.89","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-25T10:30:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_c68eb7b90acf4db39a7551bd3c12577d","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"22.93","currency":"USD","retail_rate":"22.93","retail_currency":"USD","list_rate":"24.75","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_d0c57484196644a09ac1ecd148b436f7","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":"Elmer
       Fudd","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
-      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":4,"return_address":{"id":"adr_8a9ec7ca5277481d892654e1bb26acf7","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":null,"company":"EasyPost","street1":"One
-      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6521e48856b844f3b69cbc38d251e207","object":"Address","created_at":"2021-05-21T21:20:38+00:00","updated_at":"2021-05-21T21:20:38+00:00","name":"Elmer
+      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":4,"return_address":{"id":"adr_820db84392314aa0b6fe8c88a51d0f21","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":null,"company":"EasyPost","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_d0c57484196644a09ac1ecd148b436f7","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":"Elmer
       Fudd","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
-      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_e9928c6434d54e23ba232afa8c745305","object":"Shipment"}'
+      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_94c311d5187a412da03ab102a7f89adc","object":"Shipment"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"95fd8bf66179e29333564a9fdf2ee4d2"
+      - W/"d379b48590637e7d1ea1ecb27ebf404d"
       Expires:
       - "0"
       Location:
-      - /api/v2/shipments/shp_e9928c6434d54e23ba232afa8c745305
+      - /api/v2/shipments/shp_94c311d5187a412da03ab102a7f89adc
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -225,7 +223,7 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - c2b10e7960a82426e78755620159f100
+      - bc7536fa60abe7b5e786b39a00581994
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
@@ -234,11 +232,11 @@ interactions:
       - none
       X-Proxied:
       - intlb1nuq 7ba176609e
-      - extlb1nuq 15c8815ace
+      - extlb2nuq 15c8815ace
       X-Request-Id:
-      - 0c7cecbb-59ce-4572-a2cc-8bfe2a5de76b
+      - f6ee7c50-11e3-4083-8c9b-f3a7d9ab87d9
       X-Runtime:
-      - "1.472116"
+      - "1.490389"
       X-Version-Label:
       - easypost-202105212044-9f976cba01-master
       X-Xss-Protection:
@@ -252,17 +250,17 @@ interactions:
     headers:
       User-Agent:
       - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
-    url: https://api.easypost.com/v2/shipments/shp_e9928c6434d54e23ba232afa8c745305/smartrate
+    url: https://api.easypost.com/v2/shipments/shp_94c311d5187a412da03ab102a7f89adc/smartrate
     method: GET
   response:
-    body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_c93998aa4f274a609690375f55448d09","list_currency":"USD","list_rate":32.1,"mode":"test","object":"Rate","rate":32.1,"retail_currency":"USD","retail_rate":36.9,"service":"Express","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":2,"percentile_90":3,"percentile_95":3,"percentile_97":4,"percentile_99":5},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_c40d303213564cbdb77b63c345a79c11","list_currency":"USD","list_rate":8.24,"mode":"test","object":"Rate","rate":8.24,"retail_currency":"USD","retail_rate":10.1,"service":"Priority","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":3,"percentile_97":3,"percentile_99":4},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":5,"est_delivery_days":5,"id":"rate_a7da01a0d09b42d8987740bb8d3da86d","list_currency":"USD","list_rate":8.04,"mode":"test","object":"Rate","rate":8.04,"retail_currency":"USD","retail_rate":8.04,"service":"ParcelSelect","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":5,"percentile_95":8,"percentile_97":9,"percentile_99":14},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":3,"est_delivery_days":3,"id":"rate_5aa2e8153f8942e6b6f330d9b404f16a","list_currency":"USD","list_rate":18.41,"mode":"test","object":"Rate","rate":17.44,"retail_currency":"USD","retail_rate":17.44,"service":"3DaySelect","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":3,"percentile_95":3,"percentile_97":3,"percentile_99":3},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-24T08:00:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_595a1bcabc904e23ab30fe8cefdb45d4","list_currency":"USD","list_rate":108.81,"mode":"test","object":"Rate","rate":100.84,"retail_currency":"USD","retail_rate":100.84,"service":"NextDayAirEarlyAM","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":null,"percentile_75":null,"percentile_85":null,"percentile_90":null,"percentile_95":null,"percentile_97":null,"percentile_99":null},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_0309da9a53e14e3f8244d1df6bae2665","list_currency":"USD","list_rate":26.73,"mode":"test","object":"Rate","rate":25.9,"retail_currency":"USD","retail_rate":25.9,"service":"2ndDayAirAM","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":null,"percentile_75":null,"percentile_85":null,"percentile_90":null,"percentile_95":null,"percentile_97":null,"percentile_99":null},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_dca170fe4f5c44a6a37575728be7d16e","list_currency":"USD","list_rate":12.05,"mode":"test","object":"Rate","rate":12.53,"retail_currency":"USD","retail_rate":12.53,"service":"Ground","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":3,"percentile_97":3,"percentile_99":3},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-24T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_9cdae807c79f4a7a9614ecc0520b9952","list_currency":"USD","list_rate":71.42,"mode":"test","object":"Rate","rate":64.7,"retail_currency":"USD","retail_rate":64.7,"service":"NextDayAirSaver","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":2},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-24T10:30:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_6fdf0b6c5469409dac029928b1ceaba9","list_currency":"USD","list_rate":76.71,"mode":"test","object":"Rate","rate":68.74,"retail_currency":"USD","retail_rate":68.74,"service":"NextDayAir","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":2},"updated_at":"2021-05-21T21:20:40Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-21T21:20:40Z","currency":"USD","delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_793f12d8c4e24a2e982ddfea1791c248","list_currency":"USD","list_rate":24.7,"mode":"test","object":"Rate","rate":22.88,"retail_currency":"USD","retail_rate":22.88,"service":"2ndDayAir","shipment_id":"shp_e9928c6434d54e23ba232afa8c745305","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2021-05-21T21:20:40Z"}]}'
+    body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_83f3141a48164e368889e364cc6c8874","list_currency":"USD","list_rate":32.1,"mode":"test","object":"Rate","rate":32.1,"retail_currency":"USD","retail_rate":36.9,"service":"Express","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":2,"percentile_90":3,"percentile_95":3,"percentile_97":4,"percentile_99":5},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_ab87ffdaf18c4e7cbf9415d2f9206481","list_currency":"USD","list_rate":8.24,"mode":"test","object":"Rate","rate":8.24,"retail_currency":"USD","retail_rate":10.1,"service":"Priority","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":3,"percentile_97":3,"percentile_99":4},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":5,"est_delivery_days":5,"id":"rate_49d50227310749d298468ae320246dc4","list_currency":"USD","list_rate":8.04,"mode":"test","object":"Rate","rate":8.04,"retail_currency":"USD","retail_rate":8.04,"service":"ParcelSelect","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":5,"percentile_95":8,"percentile_97":9,"percentile_99":14},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-27T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":3,"est_delivery_days":3,"id":"rate_a00964e2298547a3bc38568cc33cb8fa","list_currency":"USD","list_rate":18.46,"mode":"test","object":"Rate","rate":17.48,"retail_currency":"USD","retail_rate":17.48,"service":"3DaySelect","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":3,"percentile_95":3,"percentile_97":3,"percentile_99":3},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-25T08:00:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_a0b5aab8ca3f4acd9c5252c213f1169b","list_currency":"USD","list_rate":109.06,"mode":"test","object":"Rate","rate":101.07,"retail_currency":"USD","retail_rate":101.07,"service":"NextDayAirEarlyAM","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":null,"percentile_75":null,"percentile_85":null,"percentile_90":null,"percentile_95":null,"percentile_97":null,"percentile_99":null},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_3b73d86f9c504939abc3d98663b214ec","list_currency":"USD","list_rate":26.79,"mode":"test","object":"Rate","rate":25.97,"retail_currency":"USD","retail_rate":25.97,"service":"2ndDayAirAM","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":null,"percentile_75":null,"percentile_85":null,"percentile_90":null,"percentile_95":null,"percentile_97":null,"percentile_99":null},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_04b16abe30f34cbeb69410b5521ca781","list_currency":"USD","list_rate":12.05,"mode":"test","object":"Rate","rate":12.53,"retail_currency":"USD","retail_rate":12.53,"service":"Ground","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":3,"percentile_97":3,"percentile_99":3},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_189ca4206a164ee4b7b45e23b8d378b2","list_currency":"USD","list_rate":71.59,"mode":"test","object":"Rate","rate":64.85,"retail_currency":"USD","retail_rate":64.85,"service":"NextDayAirSaver","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":2},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-25T10:30:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_59b2c10ba3e7462ea3d29b93d21fa6ae","list_currency":"USD","list_rate":76.89,"mode":"test","object":"Rate","rate":68.9,"retail_currency":"USD","retail_rate":68.9,"service":"NextDayAir","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":2},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_c68eb7b90acf4db39a7551bd3c12577d","list_currency":"USD","list_rate":24.75,"mode":"test","object":"Rate","rate":22.93,"retail_currency":"USD","retail_rate":22.93,"service":"2ndDayAir","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2021-05-24T17:51:51Z"}]}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"5906be8a58deedfd5cf9fcfdd6180ed1"
+      - W/"e1e607d9ef9aa0b0722aa5021f3f57e7"
       Expires:
       - "0"
       Pragma:
@@ -278,20 +276,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - c2b10e7960a82428e78755620159f165
+      - bc7536fa60abe7b7e786b39a005819f3
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb2nuq
+      - bigweb4nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
       - intlb2nuq 7ba176609e
-      - extlb1nuq 15c8815ace
+      - extlb2nuq 15c8815ace
       X-Request-Id:
-      - a122a7bc-77fb-414b-a18d-77b840189ec8
+      - e583b5f8-ce67-433e-aa85-48367b988085
       X-Runtime:
-      - "0.096233"
+      - "0.125094"
       X-Version-Label:
       - easypost-202105212044-9f976cba01-master
       X-Xss-Protection:


### PR DESCRIPTION
Adds the new `/smartrate` endpoint/method on the `Shipment` object.

**NOTE:** Unlike our other client libraries using the Smartrate functionality, this will not return the `result` key but instead just the direct list of smartrates.

Simply call `GetShipmentSmartrates` and provide the shipment ID and you'll be returned a list of smartrates like so:

```json
[
        {
            "carrier": "USPS",
            "carrier_account_id": "ca_123...",
            "created_at": "2021-05-04T21:15:59Z",
            "currency": "USD",
            "delivery_date": null,
            "delivery_date_guaranteed": true,
            "delivery_days": null,
            "est_delivery_days": null,
            "id": "rate_123...",
            "list_currency": null,
            "list_rate": null,
            "mode": "test",
            "object": "Rate",
            "rate": 0.01,
            "retail_currency": null,
            "retail_rate": null,
            "service": "First",
            "shipment_id": "shp_123",
            "time_in_transit": {
                "percentile_50": 2,
                "percentile_75": 3,
                "percentile_85": 4,
                "percentile_90": 4,
                "percentile_95": 4,
                "percentile_97": 4,
                "percentile_99": 4
            },
            "updated_at": "2021-05-04T21:15:59Z"
        },
    ]
```

A full code example would look like this:

```golang
smartrates, err := client.GetShipmentSmartrates("shp_123...")
if err != nil {
    fmt.Fprintln(os.Stderr, "error retrieving smartrates:", err)
    os.Exit(1)
    return
}

prettyJSON, err := json.MarshalIndent(smartrates, "", "    ")
if err != nil {
    fmt.Fprintln(os.Stderr, "error creating JSON:", err)
    os.Exit(1)
    return
}
fmt.Println(string(prettyJSON))
```