### PR TITLE
chore: version bump v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# CHANGELOG
+
+## v1.3.1 2021-06-23
+
+* Corrects `CODAmount` from a `float64` to a `string`
+
 ## v1.3.0 2021-05-27
 
 * Adds `Smartrate` functionality to the `Shipments` object (available by calling `GetShipmentSmartrates()`)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package easypost
 
-const Version = "1.3.0"
+const Version = "1.3.1"


### PR DESCRIPTION
Bumps version from 1.3.0 to 1.3.1

* Corrects `CODAmount` from a `float64` to a `string`