### PR TITLE
remove 2015-vintage experimental "all_updated" action on trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT
+
+* Remove experimental undocumented methods `ListTrackersUpdated` and `ListTrackersUpdatedWithContext`
+
 ## v1.3.1 2021-06-23
 
 * Corrects `CODAmount` from a `float64` to a `string`

--- a/tracker.go
+++ b/tracker.go
@@ -211,19 +211,6 @@ type ListTrackersUpdatedOptions struct {
 	TrackingDetailsEnd   *time.Time `json:"tracking_details_end,omitempty"`
 }
 
-// ListTrackersUpdated returns trackers with updated data.
-func (c *Client) ListTrackersUpdated(opts *ListTrackersUpdatedOptions) (out *ListTrackersResult, err error) {
-	return c.ListTrackersUpdatedWithContext(nil, opts)
-}
-
-// ListTrackersUpdatedWithContext performs the same operation as
-// ListTrackersUpdated, but allows specifying a context that can interrupt the
-// request.
-func (c *Client) ListTrackersUpdatedWithContext(ctx context.Context, opts *ListTrackersUpdatedOptions) (out *ListTrackersResult, err error) {
-	err = c.do(ctx, http.MethodGet, "trackers/all_updated", c.convertOptsToURLValues(opts), &out)
-	return
-}
-
 // GetTracker retrieves a Tracker object by ID.
 func (c *Client) GetTracker(trackerID string) (out *Tracker, err error) {
 	err = c.get(nil, "trackers/"+trackerID, &out)


### PR DESCRIPTION
This endpoint was introduced as an experiment in 2015 and never documented. It has no users and is being removed.