### PR TITLE
feat: adds tax_identifier support

### DIFF
--- a/shipment.go
+++ b/shipment.go
@@ -135,6 +135,7 @@ type Shipment struct {
 	BatchID           string            `json:"batch_id,omitempty"`
 	BatchStatus       string            `json:"batch_status,omitempty"`
 	BatchMessage      string            `json:"batch_message,omitempty"`
+	TaxIdentifier     []*TaxIdentifier  `json:"tax_identifiers,omitempty"`
 }
 
 // CreateShipment creates a new Shipment object. The ToAddress, FromAddress and

--- a/tax_identifier.go
+++ b/tax_identifier.go
@@ -1,0 +1,9 @@
+package easypost
+
+// TaxIdentifier objects contain tax information used by carriers.
+type TaxIdentifier struct {
+	Entity         string `json:"entity,omitempty"`
+	TaxIdType      string `json:"tax_id_type,omitempty"`
+	TaxId          string `json:"tax_id,omitempty"`
+	IssuingCountry string `json:"issuing_country,omitempty"`
+}


### PR DESCRIPTION
Adds support for the new `tax_identifiers` object. 

Usage looks like the following:

```golang
			TaxIdentifier: []*easypost.TaxIdentifier{
				{
					Entity:         "RECEIVER",
					TaxIdType:      "IOSS",
					TaxId:          "12345",
					IssuingCountry: "GB",
				},
			},
```