### PR TITLE
feat: adds RerateShipment function

### DIFF
--- a/examples/shipments/rerate/rerate_shipment.go
+++ b/examples/shipments/rerate/rerate_shipment.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/EasyPost/easypost-go"
+)
+
+func main() {
+	apiKey := os.Getenv("EASYPOST_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "missing API key")
+		os.Exit(1)
+		return
+	}
+	client := easypost.New(apiKey)
+
+	// Rerate a shipment
+	rates, err := client.RerateShipment("shp_123")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error retrieving rates:", err)
+		os.Exit(1)
+		return
+	}
+
+	prettyJSON, err := json.MarshalIndent(rates, "", "    ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+		os.Exit(1)
+		return
+	}
+	fmt.Println(string(prettyJSON))
+}

--- a/shipment.go
+++ b/shipment.go
@@ -336,3 +336,18 @@ func (c *Client) RefundShipmentWithContext(ctx context.Context, shipmentID strin
 	err = c.post(ctx, "shipments/"+shipmentID+"/refund", nil, &out)
 	return
 }
+
+// RerateShipment fetches the available rates for a shipment with the current rates.
+func (c *Client) RerateShipment(shipmentID string) (out []*Rate, err error) {
+	res := &getShipmentRatesResponse{Rates: &out}
+	err = c.post(nil, "shipments/"+shipmentID+"/rerate", nil, &res)
+	return
+}
+
+// RerateShipmentWithContext performs the same operation as RerateShipment,
+// but allows specifying a context that can interrupt the request.
+func (c *Client) RerateShipmentWithContext(ctx context.Context, shipmentID string) (out []*Rate, err error) {
+	res := &getShipmentRatesResponse{Rates: &out}
+	err = c.post(ctx, "shipments/"+shipmentID+"/rerate", nil, &res)
+	return
+}


### PR DESCRIPTION
Adds the missing `RerateShipment` function. Retrieving rates via `GetShipmentRates` only retrieves rates from the original shipment creation and does not get the current rates at the time of retrieval.

This PR follows the style of this repo and the pattern of our other client libraries. I added an example file and end to end tested it. Unit testing this particular endpoint is a bit obnoxious due to the 60 second timeout we impose between the creation of a shipment and its ability to be rerated. Running the example script produces output like the following:

```json
[
    {
        "id": "rate_123",
        "object": "Rate",
        "mode": "test",
        "created_at": "2021-11-01T15:13:09Z",
        "updated_at": "2021-11-01T15:13:09Z",
        "service": "Priority",
        "carrier": "UPSMailInnovations",
        "carrier_account_id": "ca_123",
        "shipment_id": "shp_123",
        "rate": "0.01",
        "currency": "USD",
        "time_in_transit": null
    },
    {}
]
```