### PR TITLE
chore: adds new go versions to test against on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request: ~
 
 jobs:
@@ -10,20 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.12.x", "1.13.x", "1.14.x", "1.15.x"]
+        go-version: ["1.12.x", "1.13.x", "1.14.x", "1.15.x", "1.16.x", "1.17.x"]
     steps:
-    - uses: actions/checkout@v2
-    - name: use golang ${{ matrix.node-version }}
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: install dependencies
-      run: go get -u golang.org/x/lint/golint
-    - name: build
-      run: go build .
-    - name: go vet
-      run: go vet .
-    - name: go lint
-      run: golint .
-    - name: run tests
-      run: cd tests && go test -v
+      - uses: actions/checkout@v2
+      - name: use golang ${{ matrix.node-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: install dependencies
+        run: go get -u golang.org/x/lint/golint
+      - name: build
+        run: go build .
+      - name: go vet
+        run: go vet .
+      - name: go lint
+        run: golint .
+      - name: run tests
+        run: cd tests && go test -v


### PR DESCRIPTION
Adds Go 1.16 and 1.17 to the matrix of go versions we test against.