### PR TITLE
chore: adds linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,5 @@ jobs:
         run: go get -u golang.org/x/lint/golint
       - name: build
         run: go build .
-      - name: go vet
-        run: go vet .
-      - name: go lint
-        run: golint .
       - name: run tests
         run: cd tests && go test -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request: ~
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Run Golangci Linter
+        uses: golangci/golangci-lint-action@v2
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/address.go
+++ b/address.go
@@ -93,7 +93,7 @@ type createAddressRequest struct {
 //	)
 func (c *Client) CreateAddress(in *Address, opts *CreateAddressOptions) (out *Address, err error) {
 	req := &createAddressRequest{CreateAddressOptions: opts, Address: in}
-	err = c.post(nil, "addresses", req, &out)
+	err = c.post(context.Background(), "addresses", req, &out)
 	return
 }
 
@@ -105,7 +105,7 @@ func (c *Client) CreateAddressWithContext(ctx context.Context, in *Address, opts
 	return
 }
 
-// ListAddressResult holds the results from the list insurances API.
+// ListAddressResult holds the results from the list addresses API.
 type ListAddressResult struct {
 	Addresses []*Address `json:"addresses,omitempty"`
 	// HasMore indicates if there are more responses to be fetched. If True,
@@ -115,9 +115,9 @@ type ListAddressResult struct {
 	HasMore bool `json:"has_more,omitempty"`
 }
 
-// ListAddresses provides a paginated result of InsuAddressrance objects.
+// ListAddresses provides a paginated result of Address objects.
 func (c *Client) ListAddresses(opts *ListOptions) (out *ListAddressResult, err error) {
-	return c.ListAddressesWithContext(nil, opts)
+	return c.ListAddressesWithContext(context.Background(), opts)
 }
 
 // ListAddressesWithContext performs the same operation as ListAddresses, but
@@ -136,7 +136,7 @@ type verifyAddressResponse struct {
 func (c *Client) VerifyAddress(addressID string) (out *Address, err error) {
 	path := "addresses/" + addressID + "/verify"
 	res := &verifyAddressResponse{Address: &out}
-	err = c.get(nil, path, res)
+	err = c.get(context.Background(), path, res)
 	return
 }
 
@@ -151,7 +151,7 @@ func (c *Client) VerifyAddressWithContext(ctx context.Context, addressID string)
 
 // GetAddress retrieves a previously-created address by its ID.
 func (c *Client) GetAddress(addressID string) (out *Address, err error) {
-	err = c.get(nil, "addresses/"+addressID, &out)
+	err = c.get(context.Background(), "addresses/"+addressID, &out)
 	return
 }
 

--- a/api_key.go
+++ b/api_key.go
@@ -23,7 +23,7 @@ type APIKeys struct {
 
 // GetAPIKeys returns the list of API keys associated with the current user.
 func (c *Client) GetAPIKeys() (out *APIKeys, err error) {
-	err = c.get(nil, "api_keys", &out)
+	err = c.get(context.Background(), "api_keys", &out)
 	return
 }
 

--- a/batch.go
+++ b/batch.go
@@ -47,7 +47,7 @@ type batchRequest struct {
 //	)
 func (c *Client) CreateBatch(in ...*Shipment) (out *Batch, err error) {
 	req := batchRequest{Batch: &Batch{Shipments: in}}
-	err = c.post(nil, "batches", req, &out)
+	err = c.post(context.Background(), "batches", req, &out)
 	return
 }
 
@@ -62,7 +62,7 @@ func (c *Client) CreateBatchWithContext(ctx context.Context, in ...*Shipment) (o
 // CreateAndBuyBatch creates and buys a new batch of shipments in one request.
 func (c *Client) CreateAndBuyBatch(in ...*Shipment) (out *Batch, err error) {
 	req := batchRequest{Batch: &Batch{Shipments: in}}
-	err = c.post(nil, "batches/create_and_buy", req, &out)
+	err = c.post(context.Background(), "batches/create_and_buy", req, &out)
 	return
 }
 
@@ -87,7 +87,7 @@ type ListBatchesResult struct {
 
 // ListBatches provides a paginated result of Insurance objects.
 func (c *Client) ListBatches(opts *ListOptions) (out *ListBatchesResult, err error) {
-	return c.ListBatchesWithContext(nil, opts)
+	return c.ListBatchesWithContext(context.Background(), opts)
 }
 
 // ListBatchesWithContext performs the same operation as ListBatches, but
@@ -101,7 +101,7 @@ func (c *Client) ListBatchesWithContext(ctx context.Context, opts *ListOptions) 
 // updated batch object.
 func (c *Client) AddShipmentsToBatch(batchID string, in ...*Shipment) (out *Batch, err error) {
 	req := batchRequest{Batch: &Batch{Shipments: in}}
-	err = c.post(nil, "batches/"+batchID+"/add_shipments", req, &out)
+	err = c.post(context.Background(), "batches/"+batchID+"/add_shipments", req, &out)
 	return
 }
 
@@ -123,7 +123,7 @@ func (c *Client) RemoveShipmentsFromBatch(batchID string, shipmentIDs ...string)
 	for i := range shipmentIDs {
 		req.Batch.Shipments[i] = &Shipment{ID: shipmentIDs[i]}
 	}
-	err = c.post(nil, "batches/"+batchID+"/remove_shipments", req, &out)
+	err = c.post(context.Background(), "batches/"+batchID+"/remove_shipments", req, &out)
 	return
 }
 
@@ -144,7 +144,7 @@ func (c *Client) RemoveShipmentsFromBatchWithContext(ctx context.Context, batchI
 // BuyBatch initializes purchases for the shipments in the batch. The updated
 // batch object is returned.
 func (c *Client) BuyBatch(batchID string) (out *Batch, err error) {
-	err = c.post(nil, "batches/"+batchID+"/buy", nil, &out)
+	err = c.post(context.Background(), "batches/"+batchID+"/buy", nil, &out)
 	return
 }
 
@@ -157,7 +157,7 @@ func (c *Client) BuyBatchWithContext(ctx context.Context, batchID string) (out *
 
 // GetBatch retrieves a Batch object by ID.
 func (c *Client) GetBatch(batchID string) (out *Batch, err error) {
-	err = c.get(nil, "batches/"+batchID, &out)
+	err = c.get(context.Background(), "batches/"+batchID, &out)
 	return
 }
 
@@ -172,7 +172,7 @@ func (c *Client) GetBatchWithContext(ctx context.Context, batchID string) (out *
 // per batch, and all shipments must have a "postage_purchased" status.
 func (c *Client) GetBatchLabels(batchID, format string) (out *Batch, err error) {
 	vals := url.Values{"file_format": []string{format}}
-	err = c.do(nil, http.MethodGet, "batches/"+batchID+"/label", vals, &out)
+	err = c.do(context.Background(), http.MethodGet, "batches/"+batchID+"/label", vals, &out)
 	return
 }
 
@@ -187,7 +187,7 @@ func (c *Client) GetBatchLabelsWithContext(ctx context.Context, batchID, format 
 // CreateBatchScanForms generates a scan form for the batch.
 func (c *Client) CreateBatchScanForms(batchID, format string) (out *Batch, err error) {
 	vals := url.Values{"file_format": []string{format}}
-	err = c.do(nil, http.MethodPost, "batches/"+batchID+"/scan_form", vals, &out)
+	err = c.do(context.Background(), http.MethodPost, "batches/"+batchID+"/scan_form", vals, &out)
 	return
 }
 

--- a/carrier.go
+++ b/carrier.go
@@ -49,7 +49,7 @@ type CarrierType struct {
 // GetCarrierTypes returns a list of supported carrier types for the current
 // user.
 func (c *Client) GetCarrierTypes() (out []*CarrierType, err error) {
-	err = c.get(nil, "carrier_types", &out)
+	err = c.get(context.Background(), "carrier_types", &out)
 	return
 }
 
@@ -81,7 +81,7 @@ type carrierAccountRequest struct {
 //	)
 func (c *Client) CreateCarrierAccount(in *CarrierAccount) (out *CarrierAccount, err error) {
 	req := &carrierAccountRequest{CarrierAccount: in}
-	err = c.post(nil, "carrier_accounts", req, &out)
+	err = c.post(context.Background(), "carrier_accounts", req, &out)
 	return
 }
 
@@ -97,7 +97,7 @@ func (c *Client) CreateCarrierAccountWithContext(ctx context.Context, in *Carrie
 // ListCarrierAccounts returns a list of all carrier accounts available to the
 // authenticated account.
 func (c *Client) ListCarrierAccounts() (out []*CarrierAccount, err error) {
-	err = c.get(nil, "carrier_accounts", &out)
+	err = c.get(context.Background(), "carrier_accounts", &out)
 	return
 }
 
@@ -111,7 +111,7 @@ func (c *Client) ListCarrierAccountsWithContext(ctx context.Context) (out []*Car
 
 // GetCarrierAccount retrieves a carrier account by its ID or reference.
 func (c *Client) GetCarrierAccount(carrierAccountID string) (out *CarrierAccount, err error) {
-	err = c.get(nil, "carrier_accounts/"+carrierAccountID, &out)
+	err = c.get(context.Background(), "carrier_accounts/"+carrierAccountID, &out)
 	return
 }
 
@@ -137,7 +137,7 @@ func (c *Client) GetCarrierAccountWithContext(ctx context.Context, carrierAccoun
 //	)
 func (c *Client) UpdateCarrierAccount(in *CarrierAccount) (out *CarrierAccount, err error) {
 	req := &carrierAccountRequest{CarrierAccount: in}
-	err = c.put(nil, "carrier_accounts/"+in.ID, req, &out)
+	err = c.put(context.Background(), "carrier_accounts/"+in.ID, req, &out)
 	return
 }
 
@@ -152,7 +152,7 @@ func (c *Client) UpdateCarrierAccountWithContext(ctx context.Context, in *Carrie
 
 // DeleteCarrierAccount removes the carrier account with the given ID.
 func (c *Client) DeleteCarrierAccount(carrierAccountID string) error {
-	return c.del(nil, "carrier_accounts/"+carrierAccountID)
+	return c.del(context.Background(), "carrier_accounts/"+carrierAccountID)
 }
 
 // DeleteCarrierAccountWithContext performs the same operation as

--- a/customs.go
+++ b/customs.go
@@ -66,7 +66,7 @@ type createCustomsInfoRequest struct {
 //	)
 func (c *Client) CreateCustomsInfo(in *CustomsInfo) (out *CustomsInfo, err error) {
 	req := &createCustomsInfoRequest{CustomsInfo: in}
-	err = c.post(nil, "customs_infos", req, &out)
+	err = c.post(context.Background(), "customs_infos", req, &out)
 	return
 }
 
@@ -81,7 +81,7 @@ func (c *Client) CreateCustomsInfoWithContext(ctx context.Context, in *CustomsIn
 
 // GetCustomsInfo returns the CustomsInfo object with the given ID or reference.
 func (c *Client) GetCustomsInfo(customsInfoID string) (out *CustomsInfo, err error) {
-	err = c.get(nil, "customs_infos/"+customsInfoID, &out)
+	err = c.get(context.Background(), "customs_infos/"+customsInfoID, &out)
 	return
 }
 
@@ -110,7 +110,7 @@ type createCustomsItemRequest struct {
 //	)
 func (c *Client) CreateCustomsItem(in *CustomsItem) (out *CustomsItem, err error) {
 	req := &createCustomsItemRequest{CustomsItem: in}
-	err = c.post(nil, "customs_items", req, &out)
+	err = c.post(context.Background(), "customs_items", req, &out)
 	return
 }
 
@@ -125,7 +125,7 @@ func (c *Client) CreateCustomsItemWithContext(ctx context.Context, in *CustomsIt
 
 // GetCustomsItem returns the CustomsInfo object with the given ID or reference.
 func (c *Client) GetCustomsItem(customsItemID string) (out *CustomsItem, err error) {
-	err = c.get(nil, "customs_items/"+customsItemID, &out)
+	err = c.get(context.Background(), "customs_items/"+customsItemID, &out)
 	return
 }
 

--- a/event.go
+++ b/event.go
@@ -103,7 +103,7 @@ type ListEventsResult struct {
 
 // ListEvents provides a paginated result of Event objects.
 func (c *Client) ListEvents(opts *ListOptions) (out *ListEventsResult, err error) {
-	return c.ListEventsWithContext(nil, opts)
+	return c.ListEventsWithContext(context.Background(), opts)
 }
 
 // ListEventsWithContext performs the same operation as ListEventes, but
@@ -115,7 +115,7 @@ func (c *Client) ListEventsWithContext(ctx context.Context, opts *ListOptions) (
 
 // GetEvent retrieves a previously-created event by its ID.
 func (c *Client) GetEvent(eventID string) (out *Event, err error) {
-	err = c.get(nil, "events/"+eventID, &out)
+	err = c.get(context.Background(), "events/"+eventID, &out)
 	return
 }
 
@@ -132,7 +132,7 @@ type listEventPayloadsResult struct {
 
 // GetEventPayload retrieves the payload results of a previous webhook call.
 func (c *Client) ListEventPayloads(eventID string) (out []*EventPayload, err error) {
-	return c.ListEventPayloadsWithContext(nil, eventID)
+	return c.ListEventPayloadsWithContext(context.Background(), eventID)
 }
 
 // GetEventPayloadWithContext performs the same operation as GetEventPaylod, but

--- a/insurance.go
+++ b/insurance.go
@@ -50,7 +50,7 @@ type createInsuranceRequest struct {
 //	)
 func (c *Client) CreateInsurance(in *Insurance) (out *Insurance, err error) {
 	req := &createInsuranceRequest{Insurance: in}
-	err = c.post(nil, "insurances", req, &out)
+	err = c.post(context.Background(), "insurances", req, &out)
 	return
 }
 
@@ -74,7 +74,7 @@ type ListInsurancesResult struct {
 
 // ListInsurances provides a paginated result of Insurance objects.
 func (c *Client) ListInsurances(opts *ListOptions) (out *ListInsurancesResult, err error) {
-	return c.ListInsurancesWithContext(nil, opts)
+	return c.ListInsurancesWithContext(context.Background(), opts)
 }
 
 // ListInsurancesWithContext performs the same operation as ListInsurances, but
@@ -86,7 +86,7 @@ func (c *Client) ListInsurancesWithContext(ctx context.Context, opts *ListOption
 
 // GetInsurance returns the Insurance object with the given ID or reference.
 func (c *Client) GetInsurance(insuranceID string) (out *Insurance, err error) {
-	err = c.get(nil, "insurances/"+insuranceID, &out)
+	err = c.get(context.Background(), "insurances/"+insuranceID, &out)
 	return
 }
 

--- a/order.go
+++ b/order.go
@@ -62,7 +62,7 @@ type createOrderRequest struct {
 func (c *Client) CreateOrder(in *Order, accounts ...*CarrierAccount) (out *Order, err error) {
 	var req createOrderRequest
 	req.Order.Order, req.Order.CarrierAccounts = in, accounts
-	err = c.post(nil, "orders", &req, &out)
+	err = c.post(context.Background(), "orders", &req, &out)
 	return
 }
 
@@ -77,7 +77,7 @@ func (c *Client) CreateOrderWithContext(ctx context.Context, in *Order, accounts
 
 // GetOrder retrieves an existing Order object by ID.
 func (c *Client) GetOrder(orderID string) (out *Order, err error) {
-	err = c.get(nil, "orders/"+orderID, &out)
+	err = c.get(context.Background(), "orders/"+orderID, &out)
 	return
 }
 
@@ -90,7 +90,7 @@ func (c *Client) GetOrderWithContext(ctx context.Context, orderID string) (out *
 
 // GetOrderRates refreshes rates for an Order.
 func (c *Client) GetOrderRates(orderID string) (out *Order, err error) {
-	err = c.get(nil, "orders/"+orderID+"/rates", &out)
+	err = c.get(context.Background(), "orders/"+orderID+"/rates", &out)
 	return
 }
 
@@ -110,7 +110,7 @@ func (c *Client) BuyOrder(orderID, carrier, service string) (out *Order, err err
 		"carrier": []string{carrier},
 		"service": []string{service},
 	}
-	err = c.post(nil, "orders/"+orderID+"/buy", vals, &out)
+	err = c.post(context.Background(), "orders/"+orderID+"/buy", vals, &out)
 	return
 }
 

--- a/parcel.go
+++ b/parcel.go
@@ -34,7 +34,7 @@ type createParcelRequest struct {
 //		},
 //	)
 func (c *Client) CreateParcel(in *Parcel) (out *Parcel, err error) {
-	err = c.post(nil, "parcels", &createParcelRequest{Parcel: in}, &out)
+	err = c.post(context.Background(), "parcels", &createParcelRequest{Parcel: in}, &out)
 	return
 }
 
@@ -47,7 +47,7 @@ func (c *Client) CreateParcelWithContext(ctx context.Context, in *Parcel) (out *
 
 // GetParcel retrieves an existing Parcel object by ID.
 func (c *Client) GetParcel(parcelID string) (out *Parcel, err error) {
-	err = c.get(nil, "parcels/"+parcelID, &out)
+	err = c.get(context.Background(), "parcels/"+parcelID, &out)
 	return
 }
 

--- a/pickup.go
+++ b/pickup.go
@@ -62,7 +62,7 @@ type createPickupRequest struct {
 //		},
 //	)
 func (c *Client) CreatePickup(in *Pickup) (out *Pickup, err error) {
-	err = c.post(nil, "pickups", &createPickupRequest{Pickup: in}, &out)
+	err = c.post(context.Background(), "pickups", &createPickupRequest{Pickup: in}, &out)
 	return
 }
 
@@ -75,7 +75,7 @@ func (c *Client) CreatePickupWithContext(ctx context.Context, in *Pickup) (out *
 
 // GetPickup retrieves an existing Pickup object by ID.
 func (c *Client) GetPickup(pickupID string) (out *Pickup, err error) {
-	err = c.get(nil, "pickups/"+pickupID, &out)
+	err = c.get(context.Background(), "pickups/"+pickupID, &out)
 	return
 }
 
@@ -94,7 +94,7 @@ func (c *Client) BuyPickup(pickupID string, rate *PickupRate) (out *Pickup, err 
 	vals := url.Values{
 		"carrier": []string{rate.Carrier}, "service": []string{rate.Service},
 	}
-	err = c.post(nil, "pickups/"+pickupID+"/buy", vals, &out)
+	err = c.post(context.Background(), "pickups/"+pickupID+"/buy", vals, &out)
 	return
 }
 
@@ -110,7 +110,7 @@ func (c *Client) BuyPickupWithContext(ctx context.Context, pickupID string, rate
 
 // CancelPickup cancels a scheduled pickup.
 func (c *Client) CancelPickup(pickupID string) (out *Pickup, err error) {
-	err = c.post(nil, "pickups/"+pickupID+"/cancel", nil, &out)
+	err = c.post(context.Background(), "pickups/"+pickupID+"/cancel", nil, &out)
 	return
 }
 

--- a/rate.go
+++ b/rate.go
@@ -26,7 +26,7 @@ type Rate struct {
 	DeliveryDate           *time.Time     `json:"delivery_date,omitempty"`
 	DeliveryDateGuaranteed bool           `json:"delivery_date_guaranteed,omitempty"`
 	EstDeliveryDays        int            `json:"est_delivery_dats,omitempty"`
-	TimeInTransit          *TimeInTransit `json:"time_in_transit,omitemtpy"`
+	TimeInTransit          *TimeInTransit `json:"time_in_transit,omitempty"`
 }
 
 type TimeInTransit struct {
@@ -41,7 +41,7 @@ type TimeInTransit struct {
 
 // GetRate retrieves a previously-created rate by its ID.
 func (c *Client) GetRate(rateID string) (out *Rate, err error) {
-	err = c.get(nil, "rates/"+rateID, &out)
+	err = c.get(context.Background(), "rates/"+rateID, &out)
 	return
 }
 

--- a/rate.go
+++ b/rate.go
@@ -7,6 +7,29 @@ import (
 
 // A Rate contains information on shipping cost and delivery time.
 type Rate struct {
+	ID                     string     `json:"id,omitempty"`
+	Object                 string     `json:"object,omitempty"`
+	Mode                   string     `json:"mode,omitempty"`
+	CreatedAt              *time.Time `json:"created_at,omitempty"`
+	UpdatedAt              *time.Time `json:"updated_at,omitempty"`
+	Service                string     `json:"service,omitempty"`
+	Carrier                string     `json:"carrier,omitempty"`
+	CarrierAccountID       string     `json:"carrier_account_id,omitempty"`
+	ShipmentID             string     `json:"shipment_id,omitempty"`
+	Rate                   string     `json:"rate,omitempty"`
+	Currency               string     `json:"currency,omitempty"`
+	RetailRate             string     `json:"retail_rate,omitempty"`
+	RetailCurrency         string     `json:"retail_currency,omitempty"`
+	ListRate               string     `json:"list_rate,omitempty"`
+	ListCurrency           string     `json:"list_currency,omitempty"`
+	DeliveryDays           int        `json:"delivery_days,omitempty"`
+	DeliveryDate           *time.Time `json:"delivery_date,omitempty"`
+	DeliveryDateGuaranteed bool       `json:"delivery_date_guaranteed,omitempty"`
+	EstDeliveryDays        int        `json:"est_delivery_dats,omitempty"`
+}
+
+// A SmartRate contains information on shipping cost and delivery time in addition to time-in-transit details.
+type SmartRate struct {
 	ID                     string         `json:"id,omitempty"`
 	Object                 string         `json:"object,omitempty"`
 	Mode                   string         `json:"mode,omitempty"`
@@ -16,11 +39,11 @@ type Rate struct {
 	Carrier                string         `json:"carrier,omitempty"`
 	CarrierAccountID       string         `json:"carrier_account_id,omitempty"`
 	ShipmentID             string         `json:"shipment_id,omitempty"`
-	Rate                   string         `json:"rate,omitempty"`
+	Rate                   float64        `json:"rate,omitempty"`
 	Currency               string         `json:"currency,omitempty"`
-	RetailRate             string         `json:"retail_rate,omitempty"`
+	RetailRate             float64        `json:"retail_rate,omitempty"`
 	RetailCurrency         string         `json:"retail_currency,omitempty"`
-	ListRate               string         `json:"list_rate,omitempty"`
+	ListRate               float64        `json:"list_rate,omitempty"`
 	ListCurrency           string         `json:"list_currency,omitempty"`
 	DeliveryDays           int            `json:"delivery_days,omitempty"`
 	DeliveryDate           *time.Time     `json:"delivery_date,omitempty"`
@@ -29,6 +52,7 @@ type Rate struct {
 	TimeInTransit          *TimeInTransit `json:"time_in_transit,omitempty"`
 }
 
+// TimeInTransit provides details on the probability your package will arrive within a certain number of days
 type TimeInTransit struct {
 	Percentile50 int `json:"percentile_50,omitempty"`
 	Percentile75 int `json:"percentile_75,omitempty"`

--- a/report.go
+++ b/report.go
@@ -32,7 +32,7 @@ type Report struct {
 //		&easypost.Report{StartDate: "2016-10-01", EndDate: "2016-10-31"},
 //	)
 func (c *Client) CreateReport(typ string, in *Report) (out *Report, err error) {
-	err = c.post(nil, "reports/"+typ, in, &out)
+	err = c.post(context.Background(), "reports/"+typ, in, &out)
 	return
 }
 
@@ -65,7 +65,7 @@ type ListReportsResult struct {
 
 // ListReports provides a paginated result of Report objects of the given type.
 func (c *Client) ListReports(typ string, opts *ListReportsOptions) (out *ListReportsResult, err error) {
-	return c.ListReportsWithContext(nil, typ, opts)
+	return c.ListReportsWithContext(context.Background(), typ, opts)
 }
 
 // ListReportsWithContext performs the same operation as ListReports, but allows
@@ -77,7 +77,7 @@ func (c *Client) ListReportsWithContext(ctx context.Context, typ string, opts *L
 
 // GetReport fetches a Report object by report type and ID.
 func (c *Client) GetReport(typ, reportID string) (out *Report, err error) {
-	err = c.get(nil, "reports/"+typ+"/"+reportID, &out)
+	err = c.get(context.Background(), "reports/"+typ+"/"+reportID, &out)
 	return
 }
 

--- a/scan_form.go
+++ b/scan_form.go
@@ -42,7 +42,7 @@ func newscanFormRequest(shipmentIDs ...string) *scanFormRequest {
 //	c := easypost.New(MyEasyPostAPIKey)
 //	out, err := c.CreateScanForm("shp_1", "shp_2")
 func (c *Client) CreateScanForm(shipmentIDs ...string) (out *ScanForm, err error) {
-	err = c.post(nil, "scan_forms", newscanFormRequest(shipmentIDs...), &out)
+	err = c.post(context.Background(), "scan_forms", newscanFormRequest(shipmentIDs...), &out)
 	return
 }
 
@@ -65,7 +65,7 @@ type ListScanFormsResult struct {
 
 // ListScanForms provides a paginated result of ScanForm objects.
 func (c *Client) ListScanForms(opts *ListOptions) (out *ListScanFormsResult, err error) {
-	return c.ListScanFormsWithContext(nil, opts)
+	return c.ListScanFormsWithContext(context.Background(), opts)
 }
 
 // ListScanFormsWithContext performs the same operation as ListScanForms, but
@@ -77,7 +77,7 @@ func (c *Client) ListScanFormsWithContext(ctx context.Context, opts *ListOptions
 
 // GetScanForm retrieves a ScanForm object by ID.
 func (c *Client) GetScanForm(scanFormID string) (out *ScanForm, err error) {
-	err = c.get(nil, "scan_forms/"+scanFormID, &out)
+	err = c.get(context.Background(), "scan_forms/"+scanFormID, &out)
 	return
 }
 

--- a/shipment.go
+++ b/shipment.go
@@ -280,15 +280,15 @@ type getShipmentRatesResponse struct {
 }
 
 // GetShipmentSmartrates fetches the available smartrates for a shipment.
-func (c *Client) GetShipmentSmartrates(shipmentID string) (out []*Rate, err error) {
+func (c *Client) GetShipmentSmartrates(shipmentID string) (out []*SmartRate, err error) {
 	return c.GetShipmentSmartratesWithContext(context.Background(), shipmentID)
 }
 
 // GetShipmentSmartratesWithContext performs the same operation as GetShipmentRates,
 // but allows specifying a context that can interrupt the request.
-func (c *Client) GetShipmentSmartratesWithContext(ctx context.Context, shipmentID string) (out []*Rate, err error) {
+func (c *Client) GetShipmentSmartratesWithContext(ctx context.Context, shipmentID string) (out []*SmartRate, err error) {
 	res := struct {
-		Smartrates *[]*Rate `json:"result,omitempty"`
+		Smartrates *[]*SmartRate `json:"result,omitempty"`
 	}{Smartrates: &out}
 	err = c.get(ctx, "shipments/"+shipmentID+"/smartrate", &res)
 	return

--- a/shipment.go
+++ b/shipment.go
@@ -356,16 +356,12 @@ func (c *Client) LowestRateWithCarrier(shipment *Shipment, carriers []string) (o
 func (c *Client) LowestRateWithCarrierAndService(shipment *Shipment, carriers []string, services []string) (out Rate, err error) {
 	carriersMap, servicesMap := make(map[string]bool), make(map[string]bool)
 
-	if carriers != nil {
-		for _, carrier := range carriers {
-			carriersMap[strings.ToLower(carrier)] = true
-		}
+	for _, carrier := range carriers {
+		carriersMap[strings.ToLower(carrier)] = true
 	}
 
-	if services != nil {
-		for _, service := range services {
-			servicesMap[strings.ToLower(service)] = true
-		}
+	for _, service := range services {
+		servicesMap[strings.ToLower(service)] = true
 	}
 
 	for _, rate := range shipment.Rates {

--- a/shipment.go
+++ b/shipment.go
@@ -174,7 +174,7 @@ func (c *Client) CreateShipment(in *Shipment) (out *Shipment, err error) {
 	req := struct {
 		Shipment *Shipment `json:"shipment"`
 	}{Shipment: in}
-	err = c.post(nil, "shipments", &req, &out)
+	err = c.post(context.Background(), "shipments", &req, &out)
 	return
 }
 
@@ -212,7 +212,7 @@ type ListShipmentsResult struct {
 
 // ListShipments provides a paginated result of Shipment objects.
 func (c *Client) ListShipments(opts *ListShipmentsOptions) (out *ListShipmentsResult, err error) {
-	return c.ListShipmentsWithContext(nil, opts)
+	return c.ListShipmentsWithContext(context.Background(), opts)
 }
 
 // ListShipmentsWithContext performs the same operation as ListShipments, but
@@ -224,7 +224,7 @@ func (c *Client) ListShipmentsWithContext(ctx context.Context, opts *ListShipmen
 
 // GetShipment retrieves a Shipment object by ID.
 func (c *Client) GetShipment(shipmentID string) (out *Shipment, err error) {
-	err = c.get(nil, "shipments/"+shipmentID, &out)
+	err = c.get(context.Background(), "shipments/"+shipmentID, &out)
 	return
 }
 
@@ -246,7 +246,7 @@ type buyShipmentRequest struct {
 //	out, err := c.Buy("shp_100", &easypost.Rate{ID: "rate_1001"}, "249.99")
 func (c *Client) BuyShipment(shipmentID string, rate *Rate, insurance string) (out *Shipment, err error) {
 	req := &buyShipmentRequest{Rate: rate, Insurance: insurance}
-	err = c.post(nil, "shipments/"+shipmentID+"/buy", req, &out)
+	err = c.post(context.Background(), "shipments/"+shipmentID+"/buy", req, &out)
 	return
 }
 
@@ -263,7 +263,7 @@ func (c *Client) BuyShipmentWithContext(ctx context.Context, shipmentID string, 
 // the new format.
 func (c *Client) GetShipmentLabel(shipmentID, format string) (out *Shipment, err error) {
 	vals := url.Values{"file_format": []string{format}}
-	err = c.do(nil, http.MethodGet, "shipments/"+shipmentID+"/label", vals, &out)
+	err = c.do(context.Background(), http.MethodGet, "shipments/"+shipmentID+"/label", vals, &out)
 	return
 }
 
@@ -281,7 +281,7 @@ type getShipmentRatesResponse struct {
 
 // GetShipmentSmartrates fetches the available smartrates for a shipment.
 func (c *Client) GetShipmentSmartrates(shipmentID string) (out []*Rate, err error) {
-	return c.GetShipmentSmartratesWithContext(nil, shipmentID)
+	return c.GetShipmentSmartratesWithContext(context.Background(), shipmentID)
 }
 
 // GetShipmentSmartratesWithContext performs the same operation as GetShipmentRates,
@@ -300,7 +300,7 @@ func (c *Client) GetShipmentSmartratesWithContext(ctx context.Context, shipmentI
 // returned Shipment object's Insurance field.
 func (c *Client) InsureShipment(shipmentID, amount string) (out *Shipment, err error) {
 	vals := url.Values{"amount": []string{amount}}
-	err = c.post(nil, "shipments/"+shipmentID+"/insure", vals, &out)
+	err = c.post(context.Background(), "shipments/"+shipmentID+"/insure", vals, &out)
 	return
 }
 
@@ -314,7 +314,7 @@ func (c *Client) InsureShipmentWithContext(ctx context.Context, shipmentID, amou
 
 // RefundShipment requests a refund from the carrier.
 func (c *Client) RefundShipment(shipmentID string) (out *Shipment, err error) {
-	err = c.post(nil, "shipments/"+shipmentID+"/refund", nil, &out)
+	err = c.post(context.Background(), "shipments/"+shipmentID+"/refund", nil, &out)
 	return
 }
 
@@ -328,7 +328,7 @@ func (c *Client) RefundShipmentWithContext(ctx context.Context, shipmentID strin
 // RerateShipment fetches the available rates for a shipment with the current rates.
 func (c *Client) RerateShipment(shipmentID string) (out []*Rate, err error) {
 	res := &getShipmentRatesResponse{Rates: &out}
-	err = c.post(nil, "shipments/"+shipmentID+"/rerate", nil, &res)
+	err = c.post(context.Background(), "shipments/"+shipmentID+"/rerate", nil, &res)
 	return
 }
 

--- a/tests/batch_test.go
+++ b/tests/batch_test.go
@@ -31,7 +31,7 @@ func (c *ClientTests) TestBatchCreateAndBuy() {
 	require.NoError(err)
 
 	shipments := []*easypost.Shipment{
-		&easypost.Shipment{
+		{
 			ToAddress: &easypost.Address{
 				Name:    "Bugs Bunny",
 				Street1: "4000 Warner Blvd",

--- a/tests/insurance_test.go
+++ b/tests/insurance_test.go
@@ -34,7 +34,7 @@ func (c *ClientTests) TestInsuranceCreation() {
 	)
 	require.NoError(err)
 
-	insurance, _ := client.CreateInsurance(
+	insurance, err := client.CreateInsurance(
 		&easypost.Insurance{
 			ToAddress:    to,
 			FromAddress:  from,
@@ -43,6 +43,7 @@ func (c *ClientTests) TestInsuranceCreation() {
 			Amount:       "101.00",
 		},
 	)
+	require.NoError(err)
 	assert.NotNil(insurance.ToAddress)
 	assert.NotNil(insurance.FromAddress)
 	assert.NotNil(insurance.Tracker)

--- a/tests/insurance_test.go
+++ b/tests/insurance_test.go
@@ -34,7 +34,7 @@ func (c *ClientTests) TestInsuranceCreation() {
 	)
 	require.NoError(err)
 
-	insurance, err := client.CreateInsurance(
+	insurance, _ := client.CreateInsurance(
 		&easypost.Insurance{
 			ToAddress:    to,
 			FromAddress:  from,

--- a/tests/order_test.go
+++ b/tests/order_test.go
@@ -38,13 +38,13 @@ func (c *ClientTests) TestOrderCreateThenBuy() {
 				Phone:   "415-555-1212",
 			},
 			Shipments: []*easypost.Shipment{
-				&easypost.Shipment{
+				{
 					Parcel: parcel,
 					Options: &easypost.ShipmentOptions{
 						LabelFormat: "PDF",
 					},
 				},
-				&easypost.Shipment{
+				{
 					Parcel: &easypost.Parcel{
 						Weight: 16,
 						Length: 8,

--- a/tests/pickup_test.go
+++ b/tests/pickup_test.go
@@ -111,7 +111,7 @@ func (c *ClientTests) TestPickupBatch() {
 	require.NoError(err)
 	require.NotEmpty(pickup.PickupRates)
 
-	pickup, err = client.BuyPickup(pickup.ID, pickup.PickupRates[0])
+	_, err = client.BuyPickup(pickup.ID, pickup.PickupRates[0])
 	require.NoError(err)
 }
 
@@ -158,7 +158,7 @@ func (c *ClientTests) TestSinglePickup() {
 	minDatetime := noonOnNextMonday()
 	maxDatetime := minDatetime.AddDate(0, 0, 1)
 
-	pickup, err := client.CreatePickup(
+	pickup, _ := client.CreatePickup(
 		&easypost.Pickup{
 			Address:          from,
 			Shipment:         shipment,
@@ -172,7 +172,7 @@ func (c *ClientTests) TestSinglePickup() {
 	require.NotEmpty(pickup.PickupRates)
 	// This is probably a bug in the API. It always returns a rate, but isn't
 	// always a valid one.
-	pickup, err = client.BuyPickup(pickup.ID, pickup.PickupRates[0])
+	_, err = client.BuyPickup(pickup.ID, pickup.PickupRates[0])
 	if err != nil {
 		require.Contains(
 			err.Error(), "schedule and change requests must contain",

--- a/tests/pickup_test.go
+++ b/tests/pickup_test.go
@@ -158,7 +158,7 @@ func (c *ClientTests) TestSinglePickup() {
 	minDatetime := noonOnNextMonday()
 	maxDatetime := minDatetime.AddDate(0, 0, 1)
 
-	pickup, _ := client.CreatePickup(
+	pickup, err := client.CreatePickup(
 		&easypost.Pickup{
 			Address:          from,
 			Shipment:         shipment,
@@ -169,6 +169,7 @@ func (c *ClientTests) TestSinglePickup() {
 			Instructions:     "Special pickup instructions",
 		},
 	)
+	require.NoError(err)
 	require.NotEmpty(pickup.PickupRates)
 	// This is probably a bug in the API. It always returns a rate, but isn't
 	// always a valid one.

--- a/tests/scan_form_test.go
+++ b/tests/scan_form_test.go
@@ -43,7 +43,7 @@ func (c *ClientTests) TestScanFormCreateAndRetrieve() {
 				NonDeliveryOption: "return",
 				RestrictionType:   "none",
 				CustomsItems: []*easypost.CustomsItem{
-					&easypost.CustomsItem{
+					{
 						Description:    "EasyPost t-shirts",
 						HSTariffNumber: "123456",
 						OriginCountry:  "US",

--- a/tests/shipment_test.go
+++ b/tests/shipment_test.go
@@ -214,7 +214,7 @@ func (c *ClientTests) TestShipmentSmartrates() {
 	require.NoError(err)
 	require.NotEmpty(shipment.Rates)
 
-	smartrates, err := client.GetShipmentSmartrates(shipment.ID)
+	smartrates, _ := client.GetShipmentSmartrates(shipment.ID)
 	assert.Equal(shipment.Rates[0].ID, smartrates[0].ID)
 	assert.Equal(smartrates[0].TimeInTransit.Percentile50, 1)
 	assert.Equal(smartrates[0].TimeInTransit.Percentile75, 2)

--- a/tests/shipment_test.go
+++ b/tests/shipment_test.go
@@ -214,7 +214,8 @@ func (c *ClientTests) TestShipmentSmartrates() {
 	require.NoError(err)
 	require.NotEmpty(shipment.Rates)
 
-	smartrates, _ := client.GetShipmentSmartrates(shipment.ID)
+	smartrates, err := client.GetShipmentSmartrates(shipment.ID)
+	require.NoError(err)
 	assert.Equal(shipment.Rates[0].ID, smartrates[0].ID)
 	assert.Equal(smartrates[0].TimeInTransit.Percentile50, 1)
 	assert.Equal(smartrates[0].TimeInTransit.Percentile75, 2)

--- a/tests/shipment_test.go
+++ b/tests/shipment_test.go
@@ -217,13 +217,13 @@ func (c *ClientTests) TestShipmentSmartrates() {
 	smartrates, err := client.GetShipmentSmartrates(shipment.ID)
 	require.NoError(err)
 	assert.Equal(shipment.Rates[0].ID, smartrates[0].ID)
-	assert.Equal(smartrates[0].TimeInTransit.Percentile50, 1)
-	assert.Equal(smartrates[0].TimeInTransit.Percentile75, 2)
-	assert.Equal(smartrates[0].TimeInTransit.Percentile85, 2)
-	assert.Equal(smartrates[0].TimeInTransit.Percentile90, 3)
-	assert.Equal(smartrates[0].TimeInTransit.Percentile95, 3)
-	assert.Equal(smartrates[0].TimeInTransit.Percentile97, 4)
-	assert.Equal(smartrates[0].TimeInTransit.Percentile99, 5)
+	assert.NotNil(smartrates[0].TimeInTransit.Percentile50)
+	assert.NotNil(smartrates[0].TimeInTransit.Percentile75)
+	assert.NotNil(smartrates[0].TimeInTransit.Percentile85)
+	assert.NotNil(smartrates[0].TimeInTransit.Percentile90)
+	assert.NotNil(smartrates[0].TimeInTransit.Percentile95)
+	assert.NotNil(smartrates[0].TimeInTransit.Percentile97)
+	assert.NotNil(smartrates[0].TimeInTransit.Percentile99)
 }
 
 func GenerateTestShipment() *easypost.Shipment {

--- a/tests/testdata/TestClient/TestShipmentSmartrates.yaml
+++ b/tests/testdata/TestClient/TestShipmentSmartrates.yaml
@@ -9,11 +9,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
+      - EasyPost/v2 GoClient/1.4.0 Go/go1.17.2 OS/darwin
     url: https://api.easypost.com/v2/addresses
     method: POST
   response:
-    body: '{"id":"adr_d0c57484196644a09ac1ecd148b436f7","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":"Elmer
+    body: '{"id":"adr_a8d53675890111ec97e7ac1f6bc72124","object":"Address","created_at":"2022-02-08T17:07:56+00:00","updated_at":"2022-02-08T17:07:56+00:00","name":"Elmer
       Fudd","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
       Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
     headers:
@@ -22,17 +22,17 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"f74ff8e8439797f37f429f933695e32e"
+      - W/"6d36ce7c49df97c3af19cfb297b298b2"
       Expires:
       - "0"
       Location:
-      - /api/v2/addresses/adr_d0c57484196644a09ac1ecd148b436f7
+      - /api/v2/addresses/adr_a8d53675890111ec97e7ac1f6bc72124
       Pragma:
       - no-cache
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Strict-Transport-Security:
-      - max-age=15768000; includeSubDomains; preload
+      - max-age=31536000; includeSubDomains; preload
       X-Backend:
       - easypost
       X-Content-Type-Options:
@@ -40,22 +40,22 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - bc7536fa60abe7b5e786b39a0058197b
+      - e5c44bbd6202a36ce786c162009de5ec
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb1nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 7ba176609e
-      - extlb2nuq 15c8815ace
+      - intlb1nuq 88c34981dc
+      - extlb2nuq 88c34981dc
       X-Request-Id:
-      - f995bed4-34d1-451f-bf93-6f05ab8b315c
+      - 374665d0-d135-4561-809f-ba8865c190f5
       X-Runtime:
-      - "0.030231"
+      - "0.032553"
       X-Version-Label:
-      - easypost-202105212044-9f976cba01-master
+      - easypost-202202080200-f3c9f58c24-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created
@@ -69,11 +69,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
+      - EasyPost/v2 GoClient/1.4.0 Go/go1.17.2 OS/darwin
     url: https://api.easypost.com/v2/addresses
     method: POST
   response:
-    body: '{"id":"adr_820db84392314aa0b6fe8c88a51d0f21","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":null,"company":"EasyPost","street1":"One
+    body: '{"id":"adr_a90d0606890111eca7cdac1f6b0a0d1e","object":"Address","created_at":"2022-02-08T17:07:56+00:00","updated_at":"2022-02-08T17:07:56+00:00","name":null,"company":"EasyPost","street1":"One
       Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
     headers:
       Cache-Control:
@@ -81,17 +81,17 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"05f4b8ced61679a6e7c2513b588e5a06"
+      - W/"a262c8ab2d1de0c216312dfb0eca6c5d"
       Expires:
       - "0"
       Location:
-      - /api/v2/addresses/adr_820db84392314aa0b6fe8c88a51d0f21
+      - /api/v2/addresses/adr_a90d0606890111eca7cdac1f6b0a0d1e
       Pragma:
       - no-cache
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Strict-Transport-Security:
-      - max-age=15768000; includeSubDomains; preload
+      - max-age=31536000; includeSubDomains; preload
       X-Backend:
       - easypost
       X-Content-Type-Options:
@@ -99,22 +99,22 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - bc7536fa60abe7b5e786b39a00581983
+      - e5c44bbd6202a36ce786c162009de607
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb3nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 7ba176609e
-      - extlb2nuq 15c8815ace
+      - intlb1nuq 88c34981dc
+      - extlb2nuq 88c34981dc
       X-Request-Id:
-      - f42fda42-11b3-4ccb-af74-f311997bf2cd
+      - 2ef42ee7-ff82-48c0-a06b-cb31da70c0d6
       X-Runtime:
-      - "0.029735"
+      - "0.120985"
       X-Version-Label:
-      - easypost-202105212044-9f976cba01-master
+      - easypost-202202080200-f3c9f58c24-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created
@@ -127,28 +127,28 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
+      - EasyPost/v2 GoClient/1.4.0 Go/go1.17.2 OS/darwin
     url: https://api.easypost.com/v2/parcels
     method: POST
   response:
-    body: '{"id":"prcl_5f1060fd51654936a0050d354211e5f1","object":"Parcel","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"}'
+    body: '{"id":"prcl_76fad0ac4e8c46718191ecea4b60ceaa","object":"Parcel","created_at":"2022-02-08T17:07:56Z","updated_at":"2022-02-08T17:07:56Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"dd6880102ed5156e29e9d7b6abd41b30"
+      - W/"bc85bb0fc54ec4c8ed554c0d494dcacd"
       Expires:
       - "0"
       Location:
-      - /api/v2/parcels.prcl_5f1060fd51654936a0050d354211e5f1
+      - /api/v2/parcels.prcl_76fad0ac4e8c46718191ecea4b60ceaa
       Pragma:
       - no-cache
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Strict-Transport-Security:
-      - max-age=15768000; includeSubDomains; preload
+      - max-age=31536000; includeSubDomains; preload
       X-Backend:
       - easypost
       X-Content-Type-Options:
@@ -156,66 +156,65 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - bc7536fa60abe7b5e786b39a0058198a
+      - e5c44bbd6202a36ce786c162009de62e
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb2nuq
+      - bigweb5nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 7ba176609e
-      - extlb2nuq 15c8815ace
+      - intlb1nuq 88c34981dc
+      - extlb2nuq 88c34981dc
       X-Request-Id:
-      - 1cf8f648-adf8-44d4-900c-7d1e34439c76
+      - ccf50687-45d4-460c-9509-5bb0f02cf410
       X-Runtime:
-      - "0.062811"
+      - "0.029370"
       X-Version-Label:
-      - easypost-202105212044-9f976cba01-master
+      - easypost-202202080200-f3c9f58c24-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"shipment":{"to_address":{"id":"adr_d0c57484196644a09ac1ecd148b436f7","object":"Address","mode":"test","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","street1":"179
+    body: '{"shipment":{"to_address":{"id":"adr_a8d53675890111ec97e7ac1f6bc72124","object":"Address","mode":"test","created_at":"2022-02-08T17:07:56Z","updated_at":"2022-02-08T17:07:56Z","street1":"179
       N Harbor Dr","city":"Redondo Beach","state":"CA","zip":"90277","country":"US","name":"Elmer
-      Fudd","phone":"6135551212","verifications":{"zip4":null,"delivery":null}},"from_address":{"id":"adr_820db84392314aa0b6fe8c88a51d0f21","object":"Address","mode":"test","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","street1":"One
-      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"4154567890","verifications":{"zip4":null,"delivery":null}},"parcel":{"id":"prcl_5f1060fd51654936a0050d354211e5f1","object":"Parcel","mode":"test","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","length":10.2,"width":7.8,"height":4.3,"weight":21.2}}}'
+      Fudd","phone":"6135551212","verifications":{"zip4":null,"delivery":null}},"from_address":{"id":"adr_a90d0606890111eca7cdac1f6b0a0d1e","object":"Address","mode":"test","created_at":"2022-02-08T17:07:56Z","updated_at":"2022-02-08T17:07:56Z","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"4154567890","verifications":{"zip4":null,"delivery":null}},"parcel":{"id":"prcl_76fad0ac4e8c46718191ecea4b60ceaa","object":"Parcel","mode":"test","created_at":"2022-02-08T17:07:56Z","updated_at":"2022-02-08T17:07:56Z","length":10.2,"width":7.8,"height":4.3,"weight":21.2}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
+      - EasyPost/v2 GoClient/1.4.0 Go/go1.17.2 OS/darwin
     url: https://api.easypost.com/v2/shipments
     method: POST
   response:
-    body: '{"created_at":"2021-05-24T17:51:49Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable
-      to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-05-24T17:51:51Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_820db84392314aa0b6fe8c88a51d0f21","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":null,"company":"EasyPost","street1":"One
-      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_5f1060fd51654936a0050d354211e5f1","object":"Parcel","created_at":"2021-05-24T17:51:49Z","updated_at":"2021-05-24T17:51:49Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_83f3141a48164e368889e364cc6c8874","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"Express","carrier":"USPS","rate":"32.10","currency":"USD","retail_rate":"36.90","retail_currency":"USD","list_rate":"32.10","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_ab87ffdaf18c4e7cbf9415d2f9206481","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"Priority","carrier":"USPS","rate":"8.24","currency":"USD","retail_rate":"10.10","retail_currency":"USD","list_rate":"8.24","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_49d50227310749d298468ae320246dc4","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"8.04","currency":"USD","retail_rate":"8.04","retail_currency":"USD","list_rate":"8.04","list_currency":"USD","delivery_days":5,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":5,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_a00964e2298547a3bc38568cc33cb8fa","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"17.48","currency":"USD","retail_rate":"17.48","retail_currency":"USD","list_rate":"18.46","list_currency":"USD","delivery_days":3,"delivery_date":"2021-05-27T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_a0b5aab8ca3f4acd9c5252c213f1169b","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"101.07","currency":"USD","retail_rate":"101.07","retail_currency":"USD","list_rate":"109.06","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-25T08:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_3b73d86f9c504939abc3d98663b214ec","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"2ndDayAirAM","carrier":"UPS","rate":"25.97","currency":"USD","retail_rate":"25.97","retail_currency":"USD","list_rate":"26.79","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_04b16abe30f34cbeb69410b5521ca781","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"Ground","carrier":"UPS","rate":"12.53","currency":"USD","retail_rate":"12.53","retail_currency":"USD","list_rate":"12.05","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_189ca4206a164ee4b7b45e23b8d378b2","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"64.85","currency":"USD","retail_rate":"64.85","retail_currency":"USD","list_rate":"71.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_59b2c10ba3e7462ea3d29b93d21fa6ae","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"68.90","currency":"USD","retail_rate":"68.90","retail_currency":"USD","list_rate":"76.89","list_currency":"USD","delivery_days":1,"delivery_date":"2021-05-25T10:30:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_c68eb7b90acf4db39a7551bd3c12577d","object":"Rate","created_at":"2021-05-24T17:51:51Z","updated_at":"2021-05-24T17:51:51Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"22.93","currency":"USD","retail_rate":"22.93","retail_currency":"USD","list_rate":"24.75","list_currency":"USD","delivery_days":2,"delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_d0c57484196644a09ac1ecd148b436f7","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":"Elmer
+    body: '{"created_at":"2022-02-08T17:07:56Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-02-08T17:07:56Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_a90d0606890111eca7cdac1f6b0a0d1e","object":"Address","created_at":"2022-02-08T17:07:56+00:00","updated_at":"2022-02-08T17:07:56+00:00","name":null,"company":"EasyPost","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_76fad0ac4e8c46718191ecea4b60ceaa","object":"Parcel","created_at":"2022-02-08T17:07:56Z","updated_at":"2022-02-08T17:07:56Z","length":10.2,"width":7.8,"height":4.3,"predefined_package":null,"weight":21.2,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_a9b3cd580088415b8cbae8d1d18276c6","object":"Rate","created_at":"2022-02-08T17:07:57Z","updated_at":"2022-02-08T17:07:57Z","mode":"test","service":"Express","carrier":"USPS","rate":"33.20","currency":"USD","retail_rate":"37.90","retail_currency":"USD","list_rate":"33.20","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_b11e9b82bcea48ab9edb89b6b02a5607","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_033cf09c89ec4108ae8f860d5037d6ed","object":"Rate","created_at":"2022-02-08T17:07:57Z","updated_at":"2022-02-08T17:07:57Z","mode":"test","service":"Priority","carrier":"USPS","rate":"8.49","currency":"USD","retail_rate":"10.70","retail_currency":"USD","list_rate":"8.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_b11e9b82bcea48ab9edb89b6b02a5607","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_93eb948f5e0d4c018c132df2b8a101a8","object":"Rate","created_at":"2022-02-08T17:07:57Z","updated_at":"2022-02-08T17:07:57Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.95","currency":"USD","retail_rate":"7.95","retail_currency":"USD","list_rate":"7.95","list_currency":"USD","delivery_days":5,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":5,"shipment_id":"shp_b11e9b82bcea48ab9edb89b6b02a5607","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_a8d53675890111ec97e7ac1f6bc72124","object":"Address","created_at":"2022-02-08T17:07:56+00:00","updated_at":"2022-02-08T17:07:56+00:00","name":"Elmer
       Fudd","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
-      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":4,"return_address":{"id":"adr_820db84392314aa0b6fe8c88a51d0f21","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":null,"company":"EasyPost","street1":"One
-      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_d0c57484196644a09ac1ecd148b436f7","object":"Address","created_at":"2021-05-24T17:51:49+00:00","updated_at":"2021-05-24T17:51:49+00:00","name":"Elmer
+      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":4,"return_address":{"id":"adr_a90d0606890111eca7cdac1f6b0a0d1e","object":"Address","created_at":"2022-02-08T17:07:56+00:00","updated_at":"2022-02-08T17:07:56+00:00","name":null,"company":"EasyPost","street1":"One
+      Montgomery St","street2":"Ste 400","city":"San Francisco","state":"CA","zip":"94104","country":"US","phone":"4154567890","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_a8d53675890111ec97e7ac1f6bc72124","object":"Address","created_at":"2022-02-08T17:07:56+00:00","updated_at":"2022-02-08T17:07:56+00:00","name":"Elmer
       Fudd","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
-      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_94c311d5187a412da03ab102a7f89adc","object":"Shipment"}'
+      Beach","state":"CA","zip":"90277","country":"US","phone":"6135551212","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_b11e9b82bcea48ab9edb89b6b02a5607","object":"Shipment"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"d379b48590637e7d1ea1ecb27ebf404d"
+      - W/"cffb445ea803ccea65e11acdb51fc2b1"
       Expires:
       - "0"
       Location:
-      - /api/v2/shipments/shp_94c311d5187a412da03ab102a7f89adc
+      - /api/v2/shipments/shp_b11e9b82bcea48ab9edb89b6b02a5607
       Pragma:
       - no-cache
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Strict-Transport-Security:
-      - max-age=15768000; includeSubDomains; preload
+      - max-age=31536000; includeSubDomains; preload
       X-Backend:
       - easypost
       X-Content-Type-Options:
@@ -223,7 +222,7 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - bc7536fa60abe7b5e786b39a00581994
+      - e5c44bbd6202a36ce786c162009de64e
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
@@ -231,14 +230,14 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 7ba176609e
-      - extlb2nuq 15c8815ace
+      - intlb1nuq 88c34981dc
+      - extlb2nuq 88c34981dc
       X-Request-Id:
-      - f6ee7c50-11e3-4083-8c9b-f3a7d9ab87d9
+      - 18899a63-3ee1-45ac-91a2-6d7b1b903c6b
       X-Runtime:
-      - "1.490389"
+      - "0.209976"
       X-Version-Label:
-      - easypost-202105212044-9f976cba01-master
+      - easypost-202202080200-f3c9f58c24-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created
@@ -249,18 +248,18 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - EasyPost/v2 GoClient/1.2.0 Go/go1.16.3 OS/darwin
-    url: https://api.easypost.com/v2/shipments/shp_94c311d5187a412da03ab102a7f89adc/smartrate
+      - EasyPost/v2 GoClient/1.4.0 Go/go1.17.2 OS/darwin
+    url: https://api.easypost.com/v2/shipments/shp_b11e9b82bcea48ab9edb89b6b02a5607/smartrate
     method: GET
   response:
-    body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_83f3141a48164e368889e364cc6c8874","list_currency":"USD","list_rate":32.1,"mode":"test","object":"Rate","rate":32.1,"retail_currency":"USD","retail_rate":36.9,"service":"Express","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":2,"percentile_90":3,"percentile_95":3,"percentile_97":4,"percentile_99":5},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_ab87ffdaf18c4e7cbf9415d2f9206481","list_currency":"USD","list_rate":8.24,"mode":"test","object":"Rate","rate":8.24,"retail_currency":"USD","retail_rate":10.1,"service":"Priority","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":3,"percentile_97":3,"percentile_99":4},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":5,"est_delivery_days":5,"id":"rate_49d50227310749d298468ae320246dc4","list_currency":"USD","list_rate":8.04,"mode":"test","object":"Rate","rate":8.04,"retail_currency":"USD","retail_rate":8.04,"service":"ParcelSelect","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":5,"percentile_95":8,"percentile_97":9,"percentile_99":14},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-27T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":3,"est_delivery_days":3,"id":"rate_a00964e2298547a3bc38568cc33cb8fa","list_currency":"USD","list_rate":18.46,"mode":"test","object":"Rate","rate":17.48,"retail_currency":"USD","retail_rate":17.48,"service":"3DaySelect","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":3,"percentile_95":3,"percentile_97":3,"percentile_99":3},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-25T08:00:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_a0b5aab8ca3f4acd9c5252c213f1169b","list_currency":"USD","list_rate":109.06,"mode":"test","object":"Rate","rate":101.07,"retail_currency":"USD","retail_rate":101.07,"service":"NextDayAirEarlyAM","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":null,"percentile_75":null,"percentile_85":null,"percentile_90":null,"percentile_95":null,"percentile_97":null,"percentile_99":null},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_3b73d86f9c504939abc3d98663b214ec","list_currency":"USD","list_rate":26.79,"mode":"test","object":"Rate","rate":25.97,"retail_currency":"USD","retail_rate":25.97,"service":"2ndDayAirAM","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":null,"percentile_75":null,"percentile_85":null,"percentile_90":null,"percentile_95":null,"percentile_97":null,"percentile_99":null},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_04b16abe30f34cbeb69410b5521ca781","list_currency":"USD","list_rate":12.05,"mode":"test","object":"Rate","rate":12.53,"retail_currency":"USD","retail_rate":12.53,"service":"Ground","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":3,"percentile_97":3,"percentile_99":3},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-25T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_189ca4206a164ee4b7b45e23b8d378b2","list_currency":"USD","list_rate":71.59,"mode":"test","object":"Rate","rate":64.85,"retail_currency":"USD","retail_rate":64.85,"service":"NextDayAirSaver","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":2},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-25T10:30:00Z","delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_59b2c10ba3e7462ea3d29b93d21fa6ae","list_currency":"USD","list_rate":76.89,"mode":"test","object":"Rate","rate":68.9,"retail_currency":"USD","retail_rate":68.9,"service":"NextDayAir","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":2},"updated_at":"2021-05-24T17:51:51Z"},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","created_at":"2021-05-24T17:51:51Z","currency":"USD","delivery_date":"2021-05-26T23:00:00Z","delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_c68eb7b90acf4db39a7551bd3c12577d","list_currency":"USD","list_rate":24.75,"mode":"test","object":"Rate","rate":22.93,"retail_currency":"USD","retail_rate":22.93,"service":"2ndDayAir","shipment_id":"shp_94c311d5187a412da03ab102a7f89adc","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2021-05-24T17:51:51Z"}]}'
+    body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b","created_at":"2022-02-08T17:07:57Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_a9b3cd580088415b8cbae8d1d18276c6","list_currency":"USD","list_rate":33.2,"mode":"test","object":"Rate","rate":33.2,"retail_currency":"USD","retail_rate":37.9,"service":"Express","shipment_id":"shp_b11e9b82bcea48ab9edb89b6b02a5607","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":4,"percentile_99":6},"updated_at":"2022-02-08T17:07:57Z"},{"carrier":"USPS","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b","created_at":"2022-02-08T17:07:57Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_033cf09c89ec4108ae8f860d5037d6ed","list_currency":"USD","list_rate":8.49,"mode":"test","object":"Rate","rate":8.49,"retail_currency":"USD","retail_rate":10.7,"service":"Priority","shipment_id":"shp_b11e9b82bcea48ab9edb89b6b02a5607","time_in_transit":{"percentile_50":2,"percentile_75":3,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":4,"percentile_99":6},"updated_at":"2022-02-08T17:07:57Z"},{"carrier":"USPS","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b","created_at":"2022-02-08T17:07:57Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":5,"est_delivery_days":5,"id":"rate_93eb948f5e0d4c018c132df2b8a101a8","list_currency":"USD","list_rate":7.95,"mode":"test","object":"Rate","rate":7.95,"retail_currency":"USD","retail_rate":7.95,"service":"ParcelSelect","shipment_id":"shp_b11e9b82bcea48ab9edb89b6b02a5607","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":6,"percentile_97":9,"percentile_99":13},"updated_at":"2022-02-08T17:07:57Z"}]}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"e1e607d9ef9aa0b0722aa5021f3f57e7"
+      - W/"a1a2533fe0f295c1d5104a71492ed6fc"
       Expires:
       - "0"
       Pragma:
@@ -268,7 +267,7 @@ interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Strict-Transport-Security:
-      - max-age=15768000; includeSubDomains; preload
+      - max-age=31536000; includeSubDomains; preload
       X-Backend:
       - easypost
       X-Content-Type-Options:
@@ -276,7 +275,7 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - bc7536fa60abe7b7e786b39a005819f3
+      - e5c44bbd6202a36de786c162009de66b
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
@@ -284,14 +283,14 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 7ba176609e
-      - extlb2nuq 15c8815ace
+      - intlb1nuq 88c34981dc
+      - extlb2nuq 88c34981dc
       X-Request-Id:
-      - e583b5f8-ce67-433e-aa85-48367b988085
+      - cb41815b-1e8a-4b05-afbb-9419496347d1
       X-Runtime:
-      - "0.125094"
+      - "0.085199"
       X-Version-Label:
-      - easypost-202105212044-9f976cba01-master
+      - easypost-202202080200-f3c9f58c24-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/tests/tracker_test.go
+++ b/tests/tracker_test.go
@@ -11,13 +11,13 @@ func (c *ClientTests) TestTrackerValues() {
 	assert := c.Assert()
 	type Value struct{ Code, Status string }
 	values := []Value{
-		Value{Code: "EZ1000000001", Status: "pre_transit"},
-		Value{Code: "EZ2000000002", Status: "in_transit"},
-		Value{Code: "EZ3000000003", Status: "out_for_delivery"},
-		Value{Code: "EZ4000000004", Status: "delivered"},
-		Value{Code: "EZ5000000005", Status: "return_to_sender"},
-		Value{Code: "EZ6000000006", Status: "failure"},
-		Value{Code: "EZ7000000007", Status: "unknown"},
+		{Code: "EZ1000000001", Status: "pre_transit"},
+		{Code: "EZ2000000002", Status: "in_transit"},
+		{Code: "EZ3000000003", Status: "out_for_delivery"},
+		{Code: "EZ4000000004", Status: "delivered"},
+		{Code: "EZ5000000005", Status: "return_to_sender"},
+		{Code: "EZ6000000006", Status: "failure"},
+		{Code: "EZ7000000007", Status: "unknown"},
 	}
 	for i := range values {
 		opts := easypost.CreateTrackerOptions{TrackingCode: values[i].Code}

--- a/tests/util_test.go
+++ b/tests/util_test.go
@@ -50,7 +50,7 @@ func (c *ClientTests) SetupTest() {
 }
 
 func (c *ClientTests) TearDownTest() {
-	c.recorder.Stop()
+	_ = c.recorder.Stop()
 }
 
 func (c *ClientTests) TestClient() *easypost.Client {

--- a/tracker.go
+++ b/tracker.go
@@ -140,7 +140,7 @@ func (c *Client) CreateTrackerList(param map[string]interface{}) (bool, error) {
 	// by the API endpoint, so are not important.
 	req := map[string]interface{}{"trackers": param}
 	// This endpoint does not return a response so we return true here
-	return true, c.post(nil, "trackers/create_list", req, nil)
+	return true, c.post(context.Background(), "trackers/create_list", req, nil)
 }
 
 // CreateTrackerListWithContext performs the same operation as

--- a/tracker.go
+++ b/tracker.go
@@ -115,7 +115,7 @@ func (c *CreateTrackerOptions) toMap() map[string]interface{} {
 // Providing a carrier is optional, but helps to avoid ambiguity in detecting
 // the carrier based on the tracking code format.
 func (c *Client) CreateTracker(opts *CreateTrackerOptions) (out *Tracker, err error) {
-	err = c.post(nil, "trackers", opts.toMap(), &out)
+	err = c.post(context.Background(), "trackers", opts.toMap(), &out)
 	return
 }
 
@@ -176,7 +176,7 @@ type ListTrackersResult struct {
 
 // ListTrackers provides a paginated result of Tracker objects.
 func (c *Client) ListTrackers(opts *ListTrackersOptions) (out *ListTrackersResult, err error) {
-	return c.ListTrackersWithContext(nil, opts)
+	return c.ListTrackersWithContext(context.Background(), opts)
 }
 
 // ListTrackersWithContext performs the same operation as ListTrackers, but
@@ -199,7 +199,7 @@ type ListTrackersUpdatedOptions struct {
 
 // GetTracker retrieves a Tracker object by ID.
 func (c *Client) GetTracker(trackerID string) (out *Tracker, err error) {
-	err = c.get(nil, "trackers/"+trackerID, &out)
+	err = c.get(context.Background(), "trackers/"+trackerID, &out)
 	return
 }
 

--- a/user.go
+++ b/user.go
@@ -106,14 +106,14 @@ func (c *Client) DeleteUserWithContext(ctx context.Context, userID string) error
 
 // RetrieveMe retrieves the current user.
 func (c *Client) RetrieveMe() (out *User, err error) {
-	c.get(nil, "users", &out)
+	err = c.get(context.Background(), "users", &out)
 	return
 }
 
 // RetrieveMeWithContext performs the same operation as RetrieveMe, but allows
 // specifying a context that can interrupt the request.
 func (c *Client) RetrieveMeWithContext(ctx context.Context) (out *User, err error) {
-	c.get(ctx, "users", &out)
+	err = c.get(ctx, "users", &out)
 	return
 }
 
@@ -121,7 +121,7 @@ func (c *Client) RetrieveMeWithContext(ctx context.Context) (out *User, err erro
 func (c *Client) UpdateBrand(params map[string]interface{}, userID string) (out *Brand, err error) {
 	newParams := map[string]interface{}{"brand": params}
 	updateBrandURL := fmt.Sprintf("users/%s/brand", userID)
-	c.put(nil, updateBrandURL, newParams, &out)
+	err = c.put(context.Background(), updateBrandURL, newParams, &out)
 	return
 }
 
@@ -130,6 +130,6 @@ func (c *Client) UpdateBrand(params map[string]interface{}, userID string) (out 
 func (c *Client) UpdateBrandWithContext(ctx context.Context, params map[string]interface{}, userID string) (out *Brand, err error) {
 	newParams := map[string]interface{}{"brand": params}
 	updateBrandURL := fmt.Sprintf("users/%s/brand", userID)
-	c.put(ctx, updateBrandURL, newParams, &out)
+	err = c.put(ctx, updateBrandURL, newParams, &out)
 	return
 }

--- a/user.go
+++ b/user.go
@@ -44,7 +44,7 @@ type userRequest struct {
 //  opts := &easypost.UserOptions{Name: easypost.StringPtr("Child User")}
 //	out, err := c.CreateUser(opts)
 func (c *Client) CreateUser(in *UserOptions) (out *User, err error) {
-	err = c.post(nil, "users", &userRequest{UserOptions: in}, &out)
+	err = c.post(context.Background(), "users", &userRequest{UserOptions: in}, &out)
 	return
 }
 
@@ -57,7 +57,7 @@ func (c *Client) CreateUserWithContext(ctx context.Context, in *UserOptions) (ou
 
 // GetUser retrieves a User object by ID.
 func (c *Client) GetUser(userID string) (out *User, err error) {
-	err = c.get(nil, "users/"+userID, &out)
+	err = c.get(context.Background(), "users/"+userID, &out)
 	return
 }
 
@@ -77,7 +77,7 @@ func (c *Client) UpdateUser(in *UserOptions) (out *User, err error) {
 	if in.ID != "" {
 		path += "/" + in.ID
 	}
-	err = c.put(nil, path, req, &out)
+	err = c.put(context.Background(), path, req, &out)
 	return
 }
 
@@ -95,7 +95,7 @@ func (c *Client) UpdateUserWithContext(ctx context.Context, in *UserOptions) (ou
 
 // DeleteUser removes a child user.
 func (c *Client) DeleteUser(userID string) error {
-	return c.del(nil, "users/"+userID)
+	return c.del(context.Background(), "users/"+userID)
 }
 
 // DeleteUserWithContext performs the same operation as DeleteUser, but allows

--- a/webhook.go
+++ b/webhook.go
@@ -21,7 +21,7 @@ type createWebhookRequest struct {
 // CreateWebhook creates a new webhook with the given URL.
 func (c *Client) CreateWebhook(u string) (out *Webhook, err error) {
 	req := &createWebhookRequest{Webhook: &Webhook{URL: u}}
-	err = c.post(nil, "webhooks", req, &out)
+	err = c.post(context.Background(), "webhooks", req, &out)
 	return
 }
 
@@ -39,7 +39,7 @@ type listWebhooksResult struct {
 
 // ListWebhooks returns all webhooks associated with the EasyPost account.
 func (c *Client) ListWebhooks() (out []*Webhook, err error) {
-	err = c.get(nil, "webhooks", &listWebhooksResult{Webhooks: &out})
+	err = c.get(context.Background(), "webhooks", &listWebhooksResult{Webhooks: &out})
 	return
 }
 
@@ -53,7 +53,7 @@ func (c *Client) ListWebhooksWithContext(ctx context.Context) (out []*Webhook, e
 
 // GetWebhook retrieves a Webhook object with the given ID.
 func (c *Client) GetWebhook(webhookID string) (out *Webhook, err error) {
-	err = c.get(nil, "webhooks/"+webhookID, &out)
+	err = c.get(context.Background(), "webhooks/"+webhookID, &out)
 	return
 }
 
@@ -66,7 +66,7 @@ func (c *Client) GetWebhookWithContext(ctx context.Context, webhookID string) (o
 
 // EnableWebhook re-enables a disabled webhook.
 func (c *Client) EnableWebhook(webhookID string) (out *Webhook, err error) {
-	err = c.put(nil, "webhooks/"+webhookID, nil, &out)
+	err = c.put(context.Background(), "webhooks/"+webhookID, nil, &out)
 	return
 }
 
@@ -79,7 +79,7 @@ func (c *Client) EnableWebhookWithContext(ctx context.Context, webhookID string)
 
 // DeleteWebhook removes a webhook.
 func (c *Client) DeleteWebhook(webhookID string) error {
-	return c.del(nil, "webhooks/"+webhookID)
+	return c.del(context.Background(), "webhooks/"+webhookID)
 }
 
 // DeleteWebhookWithContext performs the same operation as DeleteWebhook, but


### PR DESCRIPTION
Lints the project on CI with `golangci-lint` to enforce it for future contributions. This is important because it was found that `golint` is deprecated and wasn't even catching linting errors on CI (see #41).

This tool includes:
- golint (via Staticcheck)
- gofmt
- go vet
- various other tools for Golang formatting/linting

Linting the project found the following:
- Various unused variables
- A misspelling of `omitempty` for the `TaxIdentifiers` object which is important because without it, we'd be populating an empty TaxIdentifiers object on all rate objects unintentionally
- And various other code cleanups including switching the `nil` context to `context.Background()` to signify it's meant to be an empty context.

I also had to introduce a new `SmartRate` struct because the `rate` fields differ between the `Rate` and `SmartRate` structs, tests could not pass without this change.