### PR TITLE
feat: adds support to one-call buy an order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+* Adds support to one-call buy an order
+
 ## v1.4.0 2021-10-06
 
 * Adds support for `TaxIdentifiers`

--- a/order.go
+++ b/order.go
@@ -23,6 +23,7 @@ type Order struct {
 	Rates         []*Rate           `json:"rates,omitempty"`
 	Messages      []*CarrierMessage `json:"messages,omitempty"`
 	IsReturn      bool              `json:"is_return"`
+	Service       string            `json:"service,omitempty"`
 }
 
 type createOrderRequest struct {


### PR DESCRIPTION
Adds support to one-call buy an order by adding the missing `Service` field to the order object. You one-call buy an order just as you would a shipment, by passing the `service` you want to purchase and the `carrier_account` ID of the carrier it belongs to.

This was end-to-end tested to ensure it works properly.