### PR TITLE
Add timeout option, default value for HTTP requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,7 +25,7 @@ func init() {
 	defaultUserAgent = fmt.Sprintf(
 		"EasyPost/v2 GoClient/%s Go/%s OS/%s",
 		Version, runtime.Version(), runtime.GOOS)
-	defaultTimeout = 30
+	defaultTimeout = 60
 }
 
 // A Client provides an HTTP client for EasyPost API operations.

--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ func (c *Client) userAgent() string {
 func (c *Client) timeout() time.Duration {
 	// return timeout duration in milliseconds
 	timeout := c.Timeout
-	if c.Timeout > 0 {
+	if c.Timeout <= 0 {
 		timeout = defaultTimeout
 	}
 	return time.Duration(timeout) * time.Millisecond
@@ -81,7 +81,7 @@ func (c *Client) timeout() time.Duration {
 
 func (c *Client) client() *http.Client {
 	client := c.Client
-	if client != nil {
+	if client == nil {
 		client = http.DefaultClient
 	}
 	client.Timeout = c.timeout()

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -1,0 +1,23 @@
+package easypost_test
+
+import (
+	"github.com/EasyPost/easypost-go"
+)
+
+func (c *ClientTests) TestClientTimeout() {
+	timeout1 := 1000
+	timeout2 := 10
+	tempClient := c.TestClient()
+	// set the timeout as part of the client initialization
+	client := &easypost.Client{
+		APIKey:  tempClient.APIKey,
+		Timeout: timeout1,
+	}
+	assert := c.Assert()
+	// test that property has been set correctly in the EasyPost.Client instance
+	assert.Equal(client.Timeout, timeout1)
+	// override the Timeout property after initialization
+	client.Timeout = timeout2
+	// test that property has been changed correctly
+	assert.Equal(client.Timeout, timeout2)
+}

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -15,9 +15,9 @@ func (c *ClientTests) TestClientTimeout() {
 	}
 	assert := c.Assert()
 	// test that property has been set correctly in the EasyPost.Client instance
-	assert.Equal(client.Timeout, timeout1)
+	assert.Equal(timeout1, client.Timeout)
 	// override the Timeout property after initialization
 	client.Timeout = timeout2
 	// test that property has been changed correctly
-	assert.Equal(client.Timeout, timeout2)
+	assert.Equal(timeout2, client.Timeout)
 }


### PR DESCRIPTION
Up until now, we have not provided a way for the user to set a custom timeout option for HTTP requests in our Go library.

This PR includes:
- A new `Timeout` property on the `Client` class, allowing the user to set a custom timeout for HTTP requests.
- `Timeout` defaults to 30 seconds if not set by user.

Due to using Go's built-in HTTP module, this timeout includes both the outgoing request and parsing the response.

Confirmed working by changing value and forcing timeouts during tests.