### PR TITLE
Remove get rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Adds support to update user brand
 * Adds support to create a list of trackers
 * Adds support for getting lowest rate of a shipment
-* Removed `GetShipmentRates()` and `GetShipmentRatesWithContext()` methods since the shipment struct already has rates. If you need to get new rates for a shipment, please user `RerateShipment()` method instead
+* Removed `GetShipmentRates()` and `GetShipmentRatesWithContext()` methods since the shipment struct already has rates. If you need to get new rates for a shipment, please use the `RerateShipment()` method instead
 
 ## v1.4.0 2021-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Adds support to update user brand
 * Adds support to create a list of trackers
 * Adds support for getting lowest rate of a shipment
+* Removed `GetShipmentRates` and `GetShipmentRatesWithContext` methods
+* since shipment struct already has rates. If you need to get new rates
+* for a shipment, please user `RerateShipment` method instead
 
 ## v1.4.0 2021-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@
 * Adds support to update user brand
 * Adds support to create a list of trackers
 * Adds support for getting lowest rate of a shipment
-* Removed `GetShipmentRates` and `GetShipmentRatesWithContext` methods
-* since shipment struct already has rates. If you need to get new rates
-* for a shipment, please user `RerateShipment` method instead
+* Removed `GetShipmentRates()` and `GetShipmentRatesWithContext()` methods since the shipment struct already has rates. If you need to get new rates for a shipment, please user `RerateShipment()` method instead
 
 ## v1.4.0 2021-10-06
 

--- a/shipment.go
+++ b/shipment.go
@@ -279,21 +279,6 @@ type getShipmentRatesResponse struct {
 	Rates *[]*Rate `json:"rates,omitempty"`
 }
 
-// GetShipmentRates fetches the available rates for a shipment.
-func (c *Client) GetShipmentRates(shipmentID string) (out []*Rate, err error) {
-	res := &getShipmentRatesResponse{Rates: &out}
-	err = c.get(nil, "shipments/"+shipmentID+"/rates", &res)
-	return
-}
-
-// GetShipmentRatesWithContext performs the same operation as GetShipmentRates,
-// but allows specifying a context that can interrupt the request.
-func (c *Client) GetShipmentRatesWithContext(ctx context.Context, shipmentID string) (out []*Rate, err error) {
-	res := &getShipmentRatesResponse{Rates: &out}
-	err = c.get(ctx, "shipments/"+shipmentID+"/rates", &res)
-	return
-}
-
 // GetShipmentSmartrates fetches the available smartrates for a shipment.
 func (c *Client) GetShipmentSmartrates(shipmentID string) (out []*Rate, err error) {
 	return c.GetShipmentSmartratesWithContext(nil, shipmentID)


### PR DESCRIPTION
This PR removes **GetShipmentRates()** and **GetShipmentRatesWithContext()** methods in the shipment file because the shipment struct already has rates, which makes this method unnecessary. If you need to get new rates for a shipment, please use the **RerateShipment()** method instead.