### PR TITLE
fix: module namespace by appending v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
+## v2.0.1 (2022-02-10)
+
+* Corrects namespace for v2 release from `github.com/EasyPost/easypost-go` to `github.com/EasyPost/easypost-go/v2`
+
 ## v2.0.0 (2022-02-09)
+
+**NOTE: Do not use this release, use v2.0.1 or later due to this release being incorrectly packaged.** 
 
 * Bumps minimum Go version from `1.12` to `1.15`
 * Bumps dependencies

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This work is licensed under the ISC License, a copy of which can be found at [LI
 ## Installation
 
 ```bash
-go get -u github.com/EasyPost/easypost-go
+go get -u github.com/EasyPost/easypost-go/v2
 ```
 
 ## Documentation
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/addresses/create/create_address.go
+++ b/examples/addresses/create/create_address.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/addresses/retrieve/retrieve_address.go
+++ b/examples/addresses/retrieve/retrieve_address.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/addresses/retrieve_all/retrieve_addresses.go
+++ b/examples/addresses/retrieve_all/retrieve_addresses.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/batches/create/create_batch.go
+++ b/examples/batches/create/create_batch.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/batches/retrieve/retrieve_batch.go
+++ b/examples/batches/retrieve/retrieve_batch.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/batches/retrieve_all/retrieve_batches.go
+++ b/examples/batches/retrieve_all/retrieve_batches.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/batches/scan_form_batch/scan_form_batch.go
+++ b/examples/batches/scan_form_batch/scan_form_batch.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/events/retrieve_all/retrieve_events.go
+++ b/examples/events/retrieve_all/retrieve_events.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/parcels/create/create_parcel.go
+++ b/examples/parcels/create/create_parcel.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/parcels/retrieve/retrieve_parcel.go
+++ b/examples/parcels/retrieve/retrieve_parcel.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/rates/retrieve_rate.go
+++ b/examples/rates/retrieve_rate.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/scanforms/create/create_scanform.go
+++ b/examples/scanforms/create/create_scanform.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/scanforms/retrieve/retrieve_scanform.go
+++ b/examples/scanforms/retrieve/retrieve_scanform.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/scanforms/retrieve_all/retrieve_scanforms.go
+++ b/examples/scanforms/retrieve_all/retrieve_scanforms.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/shipments/buy/buy_shipment.go
+++ b/examples/shipments/buy/buy_shipment.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/shipments/create/create_shipment.go
+++ b/examples/shipments/create/create_shipment.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/shipments/lowest_rate/lowest_rate.go
+++ b/examples/shipments/lowest_rate/lowest_rate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/shipments/rerate/rerate_shipment.go
+++ b/examples/shipments/rerate/rerate_shipment.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/shipments/retrieve/retrieve_shipment.go
+++ b/examples/shipments/retrieve/retrieve_shipment.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/shipments/retrieve_all/retrieve_shipments.go
+++ b/examples/shipments/retrieve_all/retrieve_shipments.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/trackers/create/create_tracker.go
+++ b/examples/trackers/create/create_tracker.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/trackers/retrieve/retrieve_tracker.go
+++ b/examples/trackers/retrieve/retrieve_tracker.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/trackers/retrieve_all/retrieve_trackers.go
+++ b/examples/trackers/retrieve_all/retrieve_trackers.go
@@ -3,8 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/EasyPost/easypost-go"
 	"os"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/users/update_brand.go
+++ b/examples/users/update_brand.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func main() {

--- a/examples/webhooks/handler/webhook_handler.go
+++ b/examples/webhooks/handler/webhook_handler.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 type Handler struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/EasyPost/easypost-go
+module github.com/EasyPost/easypost-go/v2
 
 go 1.15
 

--- a/tests/address_test.go
+++ b/tests/address_test.go
@@ -1,7 +1,7 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestAddressCreationVerification() {

--- a/tests/batch_test.go
+++ b/tests/batch_test.go
@@ -3,7 +3,7 @@ package easypost_test
 import (
 	"time"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestBatchCreateAndBuy() {

--- a/tests/carrier_type_test.go
+++ b/tests/carrier_type_test.go
@@ -1,7 +1,7 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestCarrierTypes() {

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -1,7 +1,7 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestClientTimeout() {

--- a/tests/error_test.go
+++ b/tests/error_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/event_test.go
+++ b/tests/event_test.go
@@ -1,6 +1,6 @@
 package easypost_test
 
-import "github.com/EasyPost/easypost-go"
+import "github.com/EasyPost/easypost-go/v2"
 
 func (c *ClientTests) TestEventsGet() {
 	client := c.TestClient()

--- a/tests/insurance_test.go
+++ b/tests/insurance_test.go
@@ -1,7 +1,7 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestInsuranceCreation() {

--- a/tests/order_test.go
+++ b/tests/order_test.go
@@ -1,7 +1,7 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestOrderCreateThenBuy() {

--- a/tests/parcel_test.go
+++ b/tests/parcel_test.go
@@ -1,7 +1,7 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestParcelCreation() {

--- a/tests/pickup_test.go
+++ b/tests/pickup_test.go
@@ -3,7 +3,7 @@ package easypost_test
 import (
 	"time"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func noonOnNextMonday() time.Time {

--- a/tests/report_test.go
+++ b/tests/report_test.go
@@ -1,7 +1,7 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestShipmentReport() {

--- a/tests/scan_form_test.go
+++ b/tests/scan_form_test.go
@@ -3,7 +3,7 @@ package easypost_test
 import (
 	"strconv"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestScanFormCreateAndRetrieve() {

--- a/tests/shipment_test.go
+++ b/tests/shipment_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestShipmentCreation() {

--- a/tests/tracker_test.go
+++ b/tests/tracker_test.go
@@ -3,7 +3,7 @@ package easypost_test
 import (
 	"strconv"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestTrackerValues() {

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -3,7 +3,7 @@ package easypost_test
 import (
 	"encoding/json"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 	"github.com/dnaeon/go-vcr/cassette"
 )
 

--- a/tests/util_test.go
+++ b/tests/util_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/stretchr/testify/suite"

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -3,7 +3,7 @@ package easypost_test
 import (
 	"net/http"
 
-	"github.com/EasyPost/easypost-go"
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestWebhooks() {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package easypost
 
-const Version = "2.0.0"
+const Version = "2.0.1"


### PR DESCRIPTION
Fixes the module namespace by adding `v2` at the end.

References:
- Description: https://donatstudios.com/Go-v2-Modules
- Examples: https://github.com/google/go-github