### PR TITLE
Add missing refund functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,10 @@
 
 ## Next Release
 
-<<<<<<< HEAD
 * Add comprehensive test coverage
 * Fix the bug for `AddShipmentsToBatch`, `AddShipmentsToBatchWithContext`, change the parameter from `string` to `interface{}` so user can pass in either Shipment IDs or Shipment structs
 * Fix the bug for `RemoveShipmentsFromBatch`, and `RemoveShipmentsFromBatchWithContext`, change the parameter from `*Shipment` to `interface{}` so user can pass in either Shipment IDs or Shipment structs
-=======
 * Add `CreateRefund`, `CreateRefundWithContext`, `ListRefunds`, `ListRefundsWithContext`, `GetRefund`, and `GetRefundWithContext` in the Refund file
->>>>>>> 0f3e912 (add missing refund functions.)
 
 ## v2.0.1 (2022-02-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Next Release
 
+<<<<<<< HEAD
 * Add comprehensive test coverage
 * Fix the bug for `AddShipmentsToBatch`, `AddShipmentsToBatchWithContext`, change the parameter from `string` to `interface{}` so user can pass in either Shipment IDs or Shipment structs
 * Fix the bug for `RemoveShipmentsFromBatch`, and `RemoveShipmentsFromBatchWithContext`, change the parameter from `*Shipment` to `interface{}` so user can pass in either Shipment IDs or Shipment structs
+=======
+* Add `CreateRefund`, `CreateRefundWithContext`, `ListRefunds`, `ListRefundsWithContext`, `GetRefund`, and `GetRefundWithContext` in the Refund file
+>>>>>>> 0f3e912 (add missing refund functions.)
 
 ## v2.0.1 (2022-02-10)
 

--- a/refund.go
+++ b/refund.go
@@ -1,6 +1,10 @@
 package easypost
 
-import "time"
+import (
+	"context"
+	"net/http"
+	"time"
+)
 
 type Refund struct {
 	ID                 string     `json:"id,omitempty"`
@@ -12,4 +16,50 @@ type Refund struct {
 	Status             string     `json:"status,omitempty"`
 	Carrier            string     `json:"carrier,omitempty"`
 	ShipmentID         string     `json:"shipment_id,omitempty"`
+}
+
+type ListRefundResult struct {
+	Refunds []*Refund `json:"refunds,omitempty"`
+	HasMore bool      `json:"has_more,omitempty"`
+}
+
+// CreateRefund submits a refund request and return a list of refunds.
+func (c *Client) CreateRefund(in map[string]interface{}) (out []*Refund, err error) {
+	req := map[string]interface{}{"refund": in}
+	err = c.post(context.Background(), "refunds", req, &out)
+	return
+}
+
+// CreateRefundWithContext performs the same operation as CreateRefund, but
+// allows specifying a context that can interrupt the request.
+func (c *Client) CreateRefundWithContext(ctx context.Context, in map[string]interface{}) (out []*Refund, err error) {
+	req := map[string]interface{}{"refund": in}
+	err = c.post(ctx, "refunds", req, &out)
+	return
+}
+
+// ListRefunds provides a paginated result of Refund objects.
+func (c *Client) ListRefunds(opts *ListOptions) (out *ListRefundResult, err error) {
+	err = c.do(context.Background(), http.MethodGet, "refunds", c.convertOptsToURLValues(opts), &out)
+	return
+}
+
+// ListRefundsWithContext performs the same operation as ListRefunds, but
+// allows specifying a context that can interrupt the request.
+func (c *Client) ListRefundsWithContext(ctx context.Context, opts *ListOptions) (out *ListRefundResult, err error) {
+	err = c.do(ctx, http.MethodGet, "refunds", c.convertOptsToURLValues(opts), &out)
+	return
+}
+
+// retrieves a previously-created Refund by its ID.
+func (c *Client) GetRefund(refundID string) (out *Refund, err error) {
+	err = c.get(context.Background(), "refunds/"+refundID, &out)
+	return
+}
+
+// GetRefundWithContext performs the same operation as GetRefund, but
+// allows specifying a context that can interrupt the request.
+func (c *Client) GetRefundWithContext(ctx context.Context, refundID string) (out *Refund, err error) {
+	err = c.get(ctx, "refunds/"+refundID, &out)
+	return
 }

--- a/tests/cassettes/TestAllRefund.yaml
+++ b/tests/cassettes/TestAllRefund.yaml
@@ -1,0 +1,59 @@
+---
+version: 1
+interactions:
+- request:
+    body: page_size=5
+    form: {}
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/refunds
+    method: GET
+  response:
+    body: '{"refunds":[{"id":"rfnd_7b3b8b3f32ab44338cd7bc08a34d2fa2","object":"Refund","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","tracking_code":"9400100897846109549866","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a"},{"id":"rfnd_db3b3dfbf38c4105bee552d0de72c618","object":"Refund","created_at":"2022-03-01T16:28:34Z","updated_at":"2022-03-01T16:28:34Z","tracking_code":"9400100897846109519364","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_4fdb053508874a6ab2fbed76d91ba56c"}],"has_more":false}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"e9698a3709e0015a0cced6815ddfdafc"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 7a24fa5b621e6f60ff23d5b700347383
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb5nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 88c34981dc
+      - intlb1wdc 88c34981dc
+      - extlb1wdc 88c34981dc
+      X-Request-Id:
+      - 34a36331-f908-47bd-907d-91620a22060d
+      X-Runtime:
+      - "0.047106"
+      X-Version-Label:
+      - easypost-202203011826-45d0115384-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/tests/cassettes/TestCreateRefund.yaml
+++ b/tests/cassettes/TestCreateRefund.yaml
@@ -1,0 +1,195 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"shipment":{"to_address":{"street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","name":"Jack Sparrow","company":"EasyPost","phone":"5555555555"},"from_address":{"street1":"388
+      Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","name":"Jack
+      Sparrow","company":"EasyPost","phone":"5555555555"},"parcel":{"length":10,"width":8,"height":4,"weight":15.4},"carrier":"USPS","service":"First","carrier_accounts":["ca_e606176ddb314afe896733636dba2f3b"]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/shipments
+    method: POST
+  response:
+    body: '{"created_at":"2022-03-01T19:09:15Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100897846109549866","updated_at":"2022-03-01T19:09:16Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_165fc14c999311ec8565ac1f6bc72124","object":"Address","created_at":"2022-03-01T19:09:15+00:00","updated_at":"2022-03-01T19:09:15+00:00","name":"Jack
+      Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_d71eb0f3b20244538184cf92a3423729","object":"Parcel","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_15a31cbc2db5479c9deb994e6ee24037","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","date_advance":0,"integrated_form":"none","label_date":"2022-03-01T19:09:16Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220301/99811f8e7685461790f1a54002c623f0.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_6762c4ff1fe24b789c6c9298f28149e6","object":"Rate","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_385edb04d3114dc29138a327439f6628","object":"Rate","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_f7eaebc40d1940c0b2e52b0fe45948b5","object":"Rate","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_4724a01f3d744ff8913f6e13b81ef305","object":"Rate","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_f7eaebc40d1940c0b2e52b0fe45948b5","object":"Rate","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},"tracker":{"id":"trk_5e3c3895280946e49070880e49351acd","object":"Tracker","mode":"test","tracking_code":"9400100897846109549866","status":"unknown","status_detail":"unknown","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzVlM2MzODk1MjgwOTQ2ZTQ5MDcwODgwZTQ5MzUxYWNk"},"to_address":{"id":"adr_165df1e2999311ec8564ac1f6bc72124","object":"Address","created_at":"2022-03-01T19:09:15+00:00","updated_at":"2022-03-01T19:09:15+00:00","name":"JACK
+      SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+      FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_165fc14c999311ec8565ac1f6bc72124","object":"Address","created_at":"2022-03-01T19:09:15+00:00","updated_at":"2022-03-01T19:09:15+00:00","name":"Jack
+      Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_165df1e2999311ec8564ac1f6bc72124","object":"Address","created_at":"2022-03-01T19:09:15+00:00","updated_at":"2022-03-01T19:09:15+00:00","name":"JACK
+      SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+      FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","object":"Shipment"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"b30fa08c25c1005285a361117464f1c4"
+      Expires:
+      - "0"
+      Location:
+      - /api/v2/shipments/shp_2cc69ae5dde14e7ba0b796bdaf04266a
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 7a24fa5c621e6f5bff23d5b500347235
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb9nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 88c34981dc
+      - intlb1wdc 88c34981dc
+      - extlb1wdc 88c34981dc
+      X-Request-Id:
+      - fb9229c1-fcd5-450b-b25c-8c2cca8b066c
+      X-Runtime:
+      - "0.876976"
+      X-Version-Label:
+      - easypost-202203011826-45d0115384-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/shipments/shp_2cc69ae5dde14e7ba0b796bdaf04266a
+    method: GET
+  response:
+    body: '{"created_at":"2022-03-01T19:09:15Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100897846109549866","updated_at":"2022-03-01T19:09:16Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_165fc14c999311ec8565ac1f6bc72124","object":"Address","created_at":"2022-03-01T19:09:15+00:00","updated_at":"2022-03-01T19:09:15+00:00","name":"Jack
+      Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_d71eb0f3b20244538184cf92a3423729","object":"Parcel","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_15a31cbc2db5479c9deb994e6ee24037","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","date_advance":0,"integrated_form":"none","label_date":"2022-03-01T19:09:16Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220301/99811f8e7685461790f1a54002c623f0.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_6762c4ff1fe24b789c6c9298f28149e6","object":"Rate","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_385edb04d3114dc29138a327439f6628","object":"Rate","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_f7eaebc40d1940c0b2e52b0fe45948b5","object":"Rate","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_4724a01f3d744ff8913f6e13b81ef305","object":"Rate","created_at":"2022-03-01T19:09:15Z","updated_at":"2022-03-01T19:09:15Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_f7eaebc40d1940c0b2e52b0fe45948b5","object":"Rate","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},"tracker":{"id":"trk_5e3c3895280946e49070880e49351acd","object":"Tracker","mode":"test","tracking_code":"9400100897846109549866","status":"pre_transit","status_detail":"status_update","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","signed_by":null,"weight":null,"est_delivery_date":"2022-03-01T19:09:16Z","shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
+      Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-02-01T19:09:16Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
+      Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-02-02T07:46:16Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
+      Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
+      TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
+      SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrXzVlM2MzODk1MjgwOTQ2ZTQ5MDcwODgwZTQ5MzUxYWNk"},"to_address":{"id":"adr_165df1e2999311ec8564ac1f6bc72124","object":"Address","created_at":"2022-03-01T19:09:15+00:00","updated_at":"2022-03-01T19:09:15+00:00","name":"JACK
+      SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+      FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_165fc14c999311ec8565ac1f6bc72124","object":"Address","created_at":"2022-03-01T19:09:15+00:00","updated_at":"2022-03-01T19:09:15+00:00","name":"Jack
+      Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_165df1e2999311ec8564ac1f6bc72124","object":"Address","created_at":"2022-03-01T19:09:15+00:00","updated_at":"2022-03-01T19:09:15+00:00","name":"JACK
+      SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+      FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a","object":"Shipment"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"fe0a79b64f5255e4895c5312c234166d"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 7a24fa5c621e6f5cff23d5b50034726b
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb3nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 88c34981dc
+      - intlb2wdc 88c34981dc
+      - extlb1wdc 88c34981dc
+      X-Request-Id:
+      - 18f5f79b-1688-4faf-9b56-ef556f0bbe33
+      X-Runtime:
+      - "0.110006"
+      X-Version-Label:
+      - easypost-202203011826-45d0115384-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"refund":{"carrier":"USPS","tracking_codes":"9400100897846109549866"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/refunds
+    method: POST
+  response:
+    body: '[{"id":"rfnd_7b3b8b3f32ab44338cd7bc08a34d2fa2","object":"Refund","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","tracking_code":"9400100897846109549866","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a"}]'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"b5a8ecf30fc568486afa0b77419588a2"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 7a24fa5c621e6f5cff23d5b50034727c
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb2nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 88c34981dc
+      - intlb1wdc 88c34981dc
+      - extlb1wdc 88c34981dc
+      X-Request-Id:
+      - a25223ac-4dc0-4609-9e94-4df4649f5dec
+      X-Runtime:
+      - "0.080121"
+      X-Version-Label:
+      - easypost-202203011826-45d0115384-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/tests/cassettes/TestRefundAll.yaml
+++ b/tests/cassettes/TestRefundAll.yaml
@@ -1,0 +1,58 @@
+---
+version: 1
+interactions:
+- request:
+    body: page_size=5
+    form: {}
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/refunds
+    method: GET
+  response:
+    body: '{"refunds":[{"id":"rfnd_649ec9199e8e44d69153e393e3835e82","object":"Refund","created_at":"2022-03-03T21:38:42Z","updated_at":"2022-03-03T21:38:42Z","tracking_code":"9400100109361109838373","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5"},{"id":"rfnd_62eb097d11e541f78b6066451a6486b1","object":"Refund","created_at":"2022-03-03T21:32:12Z","updated_at":"2022-03-03T21:32:12Z","tracking_code":"9400100109361109837499","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_db61646a9d6f41abb08a1b166effe4cd"},{"id":"rfnd_c4e6114769074715b29f3324b12e5e17","object":"Refund","created_at":"2022-03-03T21:31:54Z","updated_at":"2022-03-03T21:36:21Z","tracking_code":"9400100109361109837390","confirmation_number":null,"status":"rejected","carrier":"USPS","shipment_id":"shp_94bbcdcab86746438b95b75b1f32c8bf"},{"id":"rfnd_8ba0ec477f3d47c680333fc41dbdfc17","object":"Refund","created_at":"2022-03-03T19:09:32Z","updated_at":"2022-03-03T19:09:32Z","tracking_code":"9400100109361109822563","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_b10fd3dbbc734d1dbe4917b1b0ee6a48"},{"id":"rfnd_8a0b416e6d084e24b235c9dc5eaf0f82","object":"Refund","created_at":"2022-03-03T02:45:31Z","updated_at":"2022-03-03T02:45:31Z","tracking_code":"9400100109361109730226","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_82bbcf255b1245bd9e4a5ca39870cb30"}],"has_more":true}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"eb12530189c94e3898d82c1c74759e43"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 5ec9893c62213566ff137be20028b833
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb9nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 88c34981dc
+      - extlb1nuq 88c34981dc
+      X-Request-Id:
+      - 0d727817-f4c1-4a71-9eea-3a47585371b8
+      X-Runtime:
+      - "0.046178"
+      X-Version-Label:
+      - easypost-202203031834-4b65a7cdf4-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/tests/cassettes/TestRefundCreate.yaml
+++ b/tests/cassettes/TestRefundCreate.yaml
@@ -1,0 +1,192 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"shipment":{"to_address":{"street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","name":"Jack Sparrow","company":"EasyPost","phone":"5555555555"},"from_address":{"street1":"388
+      Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","name":"Jack
+      Sparrow","company":"EasyPost","phone":"5555555555"},"parcel":{"length":10,"width":8,"height":4,"weight":15.4},"carrier":"USPS","service":"First","carrier_accounts":["ca_e606176ddb314afe896733636dba2f3b"]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/shipments
+    method: POST
+  response:
+    body: '{"created_at":"2022-03-03T21:38:40Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361109838373","updated_at":"2022-03-03T21:38:41Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_4adb11e19b3a11ecae4aac1f6bc72124","object":"Address","created_at":"2022-03-03T21:38:40+00:00","updated_at":"2022-03-03T21:38:40+00:00","name":"Jack
+      Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_7b5d0938c5fc4c91bdb8d6c8915d8015","object":"Parcel","created_at":"2022-03-03T21:38:40Z","updated_at":"2022-03-03T21:38:40Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_1ad7c76559a84cc5b4d9c6378a62b72f","created_at":"2022-03-03T21:38:41Z","updated_at":"2022-03-03T21:38:41Z","date_advance":0,"integrated_form":"none","label_date":"2022-03-03T21:38:41Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220303/a2abfd8115984863aff59be415193846.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_6ed6158f422c4910a63fd056b9c7fe4f","object":"Rate","created_at":"2022-03-03T21:38:40Z","updated_at":"2022-03-03T21:38:40Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_f5ce14efd3e647b7b081307ef91bb40b","object":"Rate","created_at":"2022-03-03T21:38:40Z","updated_at":"2022-03-03T21:38:40Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_59a7712ebe8a40c9829c78658c68c6ed","object":"Rate","created_at":"2022-03-03T21:38:40Z","updated_at":"2022-03-03T21:38:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_dec2fa27fc7045eebf7e45bdd22c494c","object":"Rate","created_at":"2022-03-03T21:38:41Z","updated_at":"2022-03-03T21:38:41Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_59a7712ebe8a40c9829c78658c68c6ed","object":"Rate","created_at":"2022-03-03T21:38:41Z","updated_at":"2022-03-03T21:38:41Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},"tracker":{"id":"trk_63acef02f7e64af4a88f6d79848eb246","object":"Tracker","mode":"test","tracking_code":"9400100109361109838373","status":"unknown","status_detail":"unknown","created_at":"2022-03-03T21:38:41Z","updated_at":"2022-03-03T21:38:41Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzYzYWNlZjAyZjdlNjRhZjRhODhmNmQ3OTg0OGViMjQ2"},"to_address":{"id":"adr_4ad82f789b3a11ec8a83ac1f6bc7bdc6","object":"Address","created_at":"2022-03-03T21:38:40+00:00","updated_at":"2022-03-03T21:38:41+00:00","name":"JACK
+      SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+      FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_4adb11e19b3a11ecae4aac1f6bc72124","object":"Address","created_at":"2022-03-03T21:38:40+00:00","updated_at":"2022-03-03T21:38:40+00:00","name":"Jack
+      Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_4ad82f789b3a11ec8a83ac1f6bc7bdc6","object":"Address","created_at":"2022-03-03T21:38:40+00:00","updated_at":"2022-03-03T21:38:41+00:00","name":"JACK
+      SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+      FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_86725b6f3a1341b29d87141b526db5f5","object":"Shipment"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"07418fa82f6d091fbc4ddfa26a4ae450"
+      Expires:
+      - "0"
+      Location:
+      - /api/v2/shipments/shp_86725b6f3a1341b29d87141b526db5f5
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 898f4ee062213560ff137be1000556a8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb4nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 88c34981dc
+      - extlb2nuq 88c34981dc
+      X-Request-Id:
+      - 2840621c-fc4a-43ae-b644-1d6e23b30c57
+      X-Runtime:
+      - "1.250933"
+      X-Version-Label:
+      - easypost-202203031834-4b65a7cdf4-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/shipments/shp_86725b6f3a1341b29d87141b526db5f5
+    method: GET
+  response:
+    body: '{"created_at":"2022-03-03T21:38:40Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361109838373","updated_at":"2022-03-03T21:38:41Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_4adb11e19b3a11ecae4aac1f6bc72124","object":"Address","created_at":"2022-03-03T21:38:40+00:00","updated_at":"2022-03-03T21:38:40+00:00","name":"Jack
+      Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_7b5d0938c5fc4c91bdb8d6c8915d8015","object":"Parcel","created_at":"2022-03-03T21:38:40Z","updated_at":"2022-03-03T21:38:40Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_1ad7c76559a84cc5b4d9c6378a62b72f","created_at":"2022-03-03T21:38:41Z","updated_at":"2022-03-03T21:38:41Z","date_advance":0,"integrated_form":"none","label_date":"2022-03-03T21:38:41Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220303/a2abfd8115984863aff59be415193846.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_6ed6158f422c4910a63fd056b9c7fe4f","object":"Rate","created_at":"2022-03-03T21:38:40Z","updated_at":"2022-03-03T21:38:40Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_f5ce14efd3e647b7b081307ef91bb40b","object":"Rate","created_at":"2022-03-03T21:38:40Z","updated_at":"2022-03-03T21:38:40Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_59a7712ebe8a40c9829c78658c68c6ed","object":"Rate","created_at":"2022-03-03T21:38:40Z","updated_at":"2022-03-03T21:38:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},{"id":"rate_dec2fa27fc7045eebf7e45bdd22c494c","object":"Rate","created_at":"2022-03-03T21:38:41Z","updated_at":"2022-03-03T21:38:41Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_59a7712ebe8a40c9829c78658c68c6ed","object":"Rate","created_at":"2022-03-03T21:38:41Z","updated_at":"2022-03-03T21:38:41Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier_account_id":"ca_e606176ddb314afe896733636dba2f3b"},"tracker":{"id":"trk_63acef02f7e64af4a88f6d79848eb246","object":"Tracker","mode":"test","tracking_code":"9400100109361109838373","status":"pre_transit","status_detail":"status_update","created_at":"2022-03-03T21:38:41Z","updated_at":"2022-03-03T21:38:42Z","signed_by":null,"weight":null,"est_delivery_date":"2022-03-03T21:38:41Z","shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
+      Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-02-03T21:38:41Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
+      Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-02-04T10:15:41Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
+      Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
+      TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
+      SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrXzYzYWNlZjAyZjdlNjRhZjRhODhmNmQ3OTg0OGViMjQ2"},"to_address":{"id":"adr_4ad82f789b3a11ec8a83ac1f6bc7bdc6","object":"Address","created_at":"2022-03-03T21:38:40+00:00","updated_at":"2022-03-03T21:38:41+00:00","name":"JACK
+      SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+      FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_4adb11e19b3a11ecae4aac1f6bc72124","object":"Address","created_at":"2022-03-03T21:38:40+00:00","updated_at":"2022-03-03T21:38:40+00:00","name":"Jack
+      Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+      Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_4ad82f789b3a11ec8a83ac1f6bc7bdc6","object":"Address","created_at":"2022-03-03T21:38:40+00:00","updated_at":"2022-03-03T21:38:41+00:00","name":"JACK
+      SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+      FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_86725b6f3a1341b29d87141b526db5f5","object":"Shipment"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"be891c3d08a7deda36aff34c9b69f814"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 898f4ee062213562ff137be1000556fa
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb2nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 88c34981dc
+      - extlb2nuq 88c34981dc
+      X-Request-Id:
+      - 8cb63d3b-5855-49c2-9948-412d89b982ef
+      X-Runtime:
+      - "0.126567"
+      X-Version-Label:
+      - easypost-202203031834-4b65a7cdf4-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"refund":{"carrier":"USPS","tracking_codes":"9400100109361109838373"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/refunds
+    method: POST
+  response:
+    body: '[{"id":"rfnd_649ec9199e8e44d69153e393e3835e82","object":"Refund","created_at":"2022-03-03T21:38:42Z","updated_at":"2022-03-03T21:38:42Z","tracking_code":"9400100109361109838373","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5"}]'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"63055be92574d3189c7fe2398a259328"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 898f4ee062213562ff137be100055701
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb2nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 88c34981dc
+      - extlb2nuq 88c34981dc
+      X-Request-Id:
+      - 7d7acc02-5c15-4f78-8ea1-1c8814842381
+      X-Runtime:
+      - "0.081673"
+      X-Version-Label:
+      - easypost-202203031834-4b65a7cdf4-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/tests/cassettes/TestRefundRetrieve.yaml
+++ b/tests/cassettes/TestRefundRetrieve.yaml
@@ -1,0 +1,113 @@
+---
+version: 1
+interactions:
+- request:
+    body: page_size=5
+    form: {}
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/refunds
+    method: GET
+  response:
+    body: '{"refunds":[{"id":"rfnd_649ec9199e8e44d69153e393e3835e82","object":"Refund","created_at":"2022-03-03T21:38:42Z","updated_at":"2022-03-03T21:38:42Z","tracking_code":"9400100109361109838373","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5"},{"id":"rfnd_62eb097d11e541f78b6066451a6486b1","object":"Refund","created_at":"2022-03-03T21:32:12Z","updated_at":"2022-03-03T21:32:12Z","tracking_code":"9400100109361109837499","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_db61646a9d6f41abb08a1b166effe4cd"},{"id":"rfnd_c4e6114769074715b29f3324b12e5e17","object":"Refund","created_at":"2022-03-03T21:31:54Z","updated_at":"2022-03-03T21:36:21Z","tracking_code":"9400100109361109837390","confirmation_number":null,"status":"rejected","carrier":"USPS","shipment_id":"shp_94bbcdcab86746438b95b75b1f32c8bf"},{"id":"rfnd_8ba0ec477f3d47c680333fc41dbdfc17","object":"Refund","created_at":"2022-03-03T19:09:32Z","updated_at":"2022-03-03T19:09:32Z","tracking_code":"9400100109361109822563","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_b10fd3dbbc734d1dbe4917b1b0ee6a48"},{"id":"rfnd_8a0b416e6d084e24b235c9dc5eaf0f82","object":"Refund","created_at":"2022-03-03T02:45:31Z","updated_at":"2022-03-03T02:45:31Z","tracking_code":"9400100109361109730226","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_82bbcf255b1245bd9e4a5ca39870cb30"}],"has_more":true}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"eb12530189c94e3898d82c1c74759e43"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 658bd38062213568ff137be40002de10
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb4nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 88c34981dc
+      - intlb1wdc 88c34981dc
+      - extlb3wdc 88c34981dc
+      X-Request-Id:
+      - 50e6734c-ff5c-413f-869d-5e2e3c3c7233
+      X-Runtime:
+      - "0.050044"
+      X-Version-Label:
+      - easypost-202203031834-4b65a7cdf4-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/refunds/rfnd_649ec9199e8e44d69153e393e3835e82
+    method: GET
+  response:
+    body: '{"id":"rfnd_649ec9199e8e44d69153e393e3835e82","object":"Refund","created_at":"2022-03-03T21:38:42Z","updated_at":"2022-03-03T21:38:42Z","tracking_code":"9400100109361109838373","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_86725b6f3a1341b29d87141b526db5f5"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"30c2c19eb5c4eb6d38b24416f0547a96"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 658bd38062213568ff137be40002de1b
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb5nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 88c34981dc
+      - intlb1wdc 88c34981dc
+      - extlb3wdc 88c34981dc
+      X-Request-Id:
+      - f771559c-3367-4d17-ad92-2d1f8f561ca4
+      X-Runtime:
+      - "0.050743"
+      X-Version-Label:
+      - easypost-202203031834-4b65a7cdf4-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/tests/cassettes/TestRetrieveRefund.yaml
+++ b/tests/cassettes/TestRetrieveRefund.yaml
@@ -1,0 +1,113 @@
+---
+version: 1
+interactions:
+- request:
+    body: page_size=5
+    form: {}
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/refunds
+    method: GET
+  response:
+    body: '{"refunds":[{"id":"rfnd_7b3b8b3f32ab44338cd7bc08a34d2fa2","object":"Refund","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","tracking_code":"9400100897846109549866","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a"},{"id":"rfnd_db3b3dfbf38c4105bee552d0de72c618","object":"Refund","created_at":"2022-03-01T16:28:34Z","updated_at":"2022-03-01T16:28:34Z","tracking_code":"9400100897846109519364","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_4fdb053508874a6ab2fbed76d91ba56c"}],"has_more":false}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"e9698a3709e0015a0cced6815ddfdafc"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 7a24fa5b621e6f64ff23d5b800347483
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb1nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 88c34981dc
+      - intlb1wdc 88c34981dc
+      - extlb1wdc 88c34981dc
+      X-Request-Id:
+      - 010fb843-72a6-4c68-973d-e53443980d22
+      X-Runtime:
+      - "0.051545"
+      X-Version-Label:
+      - easypost-202203011826-45d0115384-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/refunds/rfnd_7b3b8b3f32ab44338cd7bc08a34d2fa2
+    method: GET
+  response:
+    body: '{"id":"rfnd_7b3b8b3f32ab44338cd7bc08a34d2fa2","object":"Refund","created_at":"2022-03-01T19:09:16Z","updated_at":"2022-03-01T19:09:16Z","tracking_code":"9400100897846109549866","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_2cc69ae5dde14e7ba0b796bdaf04266a"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"bef0f606ef5c21b7c88392fbb3f483c1"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 7a24fa5b621e6f64ff23d5b800347491
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb8nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 88c34981dc
+      - intlb2wdc 88c34981dc
+      - extlb1wdc 88c34981dc
+      X-Request-Id:
+      - dc610338-9186-4963-87cd-360dc8c69a67
+      X-Runtime:
+      - "0.047051"
+      X-Version-Label:
+      - easypost-202203011826-45d0115384-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/tests/refund_test.go
+++ b/tests/refund_test.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 )
 
-func (c *ClientTests) TestCreateRefund() {
+func (c *ClientTests) TestRefundCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(OneCallBuyShipment())
+	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
 
 	retrievedShipment, _ := client.GetShipment(shipment.ID) // We need to retrieve the shipment so that the tracking_code has time to populate
 
@@ -25,32 +25,32 @@ func (c *ClientTests) TestCreateRefund() {
 	assert.Equal("submitted", refund[0].Status)
 }
 
-func (c *ClientTests) TestAllRefund() {
+func (c *ClientTests) TestRefundAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
 	refunds, _ := client.ListRefunds(
 		&easypost.ListOptions{
-			PageSize: 5,
+			PageSize: c.fixture.pageSize(),
 		},
 	)
 
 	refundsList := refunds.Refunds
 
-	assert.LessOrEqual(len(refundsList), 5)
+	assert.LessOrEqual(len(refundsList), c.fixture.pageSize())
 	assert.NotNil(refunds.HasMore)
 	for _, refund := range refundsList {
 		assert.Equal(reflect.TypeOf(&easypost.Refund{}), reflect.TypeOf(refund))
 	}
 }
 
-func (c *ClientTests) TestRetrieveRefund() {
+func (c *ClientTests) TestRefundRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
 	refunds, _ := client.ListRefunds(
 		&easypost.ListOptions{
-			PageSize: 5,
+			PageSize: c.fixture.pageSize(),
 		},
 	)
 
@@ -58,37 +58,4 @@ func (c *ClientTests) TestRetrieveRefund() {
 
 	assert.Equal(reflect.TypeOf(&easypost.Refund{}), reflect.TypeOf(retrievedRefund))
 	assert.Equal(refunds.Refunds[0].ID, retrievedRefund.ID)
-}
-
-func BasicAddress() *easypost.Address {
-	return &easypost.Address{
-		Name:    "Jack Sparrow",
-		Company: "EasyPost",
-		Street1: "388 Townsend St",
-		Street2: "Apt 20",
-		City:    "San Francisco",
-		State:   "CA",
-		Zip:     "94107",
-		Phone:   "5555555555",
-	}
-}
-
-func BasicParcel() *easypost.Parcel {
-	return &easypost.Parcel{
-		Length: 10,
-		Width:  8,
-		Height: 4,
-		Weight: 15.4,
-	}
-}
-
-func OneCallBuyShipment() *easypost.Shipment {
-	return &easypost.Shipment{
-		ToAddress:         BasicAddress(),
-		FromAddress:       BasicAddress(),
-		Parcel:            BasicParcel(),
-		Service:           "First",
-		CarrierAccountIDs: []string{"ca_e606176ddb314afe896733636dba2f3b"},
-		Carrier:           "USPS",
-	}
 }

--- a/tests/refund_test.go
+++ b/tests/refund_test.go
@@ -1,0 +1,94 @@
+package easypost_test
+
+import (
+	"github.com/EasyPost/easypost-go/v2"
+	"reflect"
+	"strings"
+)
+
+func (c *ClientTests) TestCreateRefund() {
+	client := c.TestClient()
+	assert := c.Assert()
+
+	shipment, _ := client.CreateShipment(OneCallBuyShipment())
+
+	retrievedShipment, _ := client.GetShipment(shipment.ID) // We need to retrieve the shipment so that the tracking_code has time to populate
+
+	refund, _ := client.CreateRefund(
+		map[string]interface{}{
+			"carrier":        "USPS",
+			"tracking_codes": retrievedShipment.TrackingCode,
+		},
+	)
+
+	assert.True(strings.HasPrefix(refund[0].ID, "rfnd_"))
+	assert.Equal("submitted", refund[0].Status)
+}
+
+func (c *ClientTests) TestAllRefund() {
+	client := c.TestClient()
+	assert := c.Assert()
+
+	refunds, _ := client.ListRefunds(
+		&easypost.ListOptions{
+			PageSize: 5,
+		},
+	)
+
+	refundsList := refunds.Refunds
+
+	assert.LessOrEqual(len(refundsList), 5)
+	assert.NotNil(refunds.HasMore)
+	for _, refund := range refundsList {
+		assert.Equal(reflect.TypeOf(&easypost.Refund{}), reflect.TypeOf(refund))
+	}
+}
+
+func (c *ClientTests) TestRetrieveRefund() {
+	client := c.TestClient()
+	assert := c.Assert()
+
+	refunds, _ := client.ListRefunds(
+		&easypost.ListOptions{
+			PageSize: 5,
+		},
+	)
+
+	retrievedRefund, _ := client.GetRefund(refunds.Refunds[0].ID)
+
+	assert.Equal(reflect.TypeOf(&easypost.Refund{}), reflect.TypeOf(retrievedRefund))
+	assert.Equal(refunds.Refunds[0].ID, retrievedRefund.ID)
+}
+
+func BasicAddress() *easypost.Address {
+	return &easypost.Address{
+		Name:    "Jack Sparrow",
+		Company: "EasyPost",
+		Street1: "388 Townsend St",
+		Street2: "Apt 20",
+		City:    "San Francisco",
+		State:   "CA",
+		Zip:     "94107",
+		Phone:   "5555555555",
+	}
+}
+
+func BasicParcel() *easypost.Parcel {
+	return &easypost.Parcel{
+		Length: 10,
+		Width:  8,
+		Height: 4,
+		Weight: 15.4,
+	}
+}
+
+func OneCallBuyShipment() *easypost.Shipment {
+	return &easypost.Shipment{
+		ToAddress:         BasicAddress(),
+		FromAddress:       BasicAddress(),
+		Parcel:            BasicParcel(),
+		Service:           "First",
+		CarrierAccountIDs: []string{"ca_e606176ddb314afe896733636dba2f3b"},
+		Carrier:           "USPS",
+	}
+}


### PR DESCRIPTION
This PR adds missing functions in Refund.

- Add `CreateRefund`, `CreateRefundWithContext`, `ListRefunds`, `ListRefundsWithContext`, `GetRefund`, and `GetRefundWithContext` in the Refund file
