### PR TITLE
[feat] Support for `columns` and `additional_columns` on Report creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## NEXT RELEASE
+- Adds custom columns and additional columns to `CreateReport` function
+
 ## v2.2.0 (2022-03-08)
 
 - Adds missing `CreateAndVerifyAddress` and `CreateAndVerifyAddressWithContext` functions

--- a/report.go
+++ b/report.go
@@ -9,23 +9,25 @@ import (
 // Report represents a CSV-formatted file that is a log of all the objects
 // created within a certain time frame.
 type Report struct {
-	ID              string     `json:"id,omitempty"`
-	Object          string     `json:"object,omitempty"`
-	Mode            string     `json:"mode,omitempty"`
-	CreatedAt       *time.Time `json:"created_at,omitempty"`
-	UpdatedAt       *time.Time `json:"updated_at,omitempty"`
-	Status          string     `json:"status,omitempty"`
-	StartDate       string     `json:"start_date,omitempty"`
-	EndDate         string     `json:"end_date,omitempty"`
-	IncludeChildren bool       `json:"include_children,omitempty"`
-	URL             string     `json:"url,omitempty"`
-	URLExpiresAt    *time.Time `json:"url_expires_at,omitempty"`
-	SendEmail       bool       `json:"send_email,omitempty"`
+	ID                string     `json:"id,omitempty"`
+	Object            string     `json:"object,omitempty"`
+	Mode              string     `json:"mode,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
+	Status            string     `json:"status,omitempty"`
+	StartDate         string     `json:"start_date,omitempty"`
+	EndDate           string     `json:"end_date,omitempty"`
+	IncludeChildren   bool       `json:"include_children,omitempty"`
+	URL               string     `json:"url,omitempty"`
+	URLExpiresAt      *time.Time `json:"url_expires_at,omitempty"`
+	SendEmail         bool       `json:"send_email,omitempty"`
+	Columns           []string   `json:"columns,omitempty"`
+	AdditionalColumns []string   `json:"additional_columns,omitempty"`
 }
 
 // CreateReport generates a new report. Valid Fields for input are StartDate,
 // EndDate and SendEmail. A new Report object is returned. Once the Status is
-// available, the report can be downloded from the provided URL for 30 seconds.
+// available, the report can be downloaded from the provided URL for 30 seconds.
 //	c := easypost.New(MyEasyPostAPIKey)
 //	c.CreateReport(
 //		"payment_log",

--- a/tests/cassettes/TestReportCustomAdditionalColumnsCreate.yaml
+++ b/tests/cassettes/TestReportCustomAdditionalColumnsCreate.yaml
@@ -1,0 +1,56 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"start_date":"2022-02-26","end_date":"2022-02-27","additional_columns":["from_name","from_company"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/2.2.0 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/reports/shipment
+    method: POST
+  response:
+    body: '{"id":"shprep_4758d428cc98496198d2fbf9ec704d16","object":"ShipmentReport","created_at":"2022-03-23T20:19:22Z","updated_at":"2022-03-23T20:19:22Z","start_date":"2022-02-26","end_date":"2022-02-27","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"a6da6e31abb8c4a883bc7f221988ec91"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 4aee9dd4623b80cae78a8f0800094d2a
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb3nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 3e97db20d4
+      - extlb1nuq 3e97db20d4
+      X-Runtime:
+      - "0.037018"
+      X-Version-Label:
+      - easypost-202203231943-61a988cd70-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/tests/cassettes/TestReportCustomColumnsCreate.yaml
+++ b/tests/cassettes/TestReportCustomColumnsCreate.yaml
@@ -1,0 +1,56 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"start_date":"2022-02-26","end_date":"2022-02-27","columns":["usps_zone"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - EasyPost/v2 GoClient/2.2.0 Go/go1.17.5 OS/darwin
+    url: https://api.easypost.com/v2/reports/shipment
+    method: POST
+  response:
+    body: '{"id":"shprep_73e82932c5d64792b0f19303e325fd89","object":"ShipmentReport","created_at":"2022-03-23T20:19:36Z","updated_at":"2022-03-23T20:19:36Z","start_date":"2022-02-26","end_date":"2022-02-27","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"90977fd794f716f7d602bd7c9ebbef8a"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 4aee9dd2623b80d8e78a8f090009507a
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb4nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 3e97db20d4
+      - extlb1nuq 3e97db20d4
+      X-Runtime:
+      - "0.043252"
+      X-Version-Label:
+      - easypost-202203231943-61a988cd70-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/tests/report_test.go
+++ b/tests/report_test.go
@@ -100,6 +100,11 @@ func (c *ClientTests) TestReportCustomColumnsCreate() {
 		},
 	)
 
+	// verify parameters by checking VCR cassette for correct URL
+	// Some reports take a long time to generate, so we won't be able to consistently pull the report
+	// There's unfortunately no way to check if the columns were included in the final report without parsing the CSV
+	// so we assume, if we haven't gotten an error by this point, we've made the API calls correctly
+	// any failure at this point is a server-side issue
 	assert.Equal(reflect.TypeOf(&easypost.Report{}), reflect.TypeOf(report))
 }
 
@@ -116,6 +121,11 @@ func (c *ClientTests) TestReportCustomAdditionalColumnsCreate() {
 		},
 	)
 
+	// verify parameters by checking VCR cassette for correct URL
+	// Some reports take a long time to generate, so we won't be able to consistently pull the report
+	// There's unfortunately no way to check if the columns were included in the final report without parsing the CSV
+	// so we assume, if we haven't gotten an error by this point, we've made the API calls correctly
+	// any failure at this point is a server-side issue
 	assert.Equal(reflect.TypeOf(&easypost.Report{}), reflect.TypeOf(report))
 }
 

--- a/tests/report_test.go
+++ b/tests/report_test.go
@@ -87,6 +87,38 @@ func (c *ClientTests) TestReportTrackerCreate() {
 	assert.True(strings.HasPrefix(report.ID, "trkrep_"))
 }
 
+func (c *ClientTests) TestReportCustomColumnsCreate() {
+	client := c.TestClient()
+	assert := c.Assert()
+
+	report, _ := client.CreateReport(
+		"shipment",
+		&easypost.Report{
+			StartDate: c.fixture.ReportStartDate(),
+			EndDate:   c.fixture.ReportEndDate(),
+			Columns:   []string{"usps_zone"},
+		},
+	)
+
+	assert.Equal(reflect.TypeOf(&easypost.Report{}), reflect.TypeOf(report))
+}
+
+func (c *ClientTests) TestReportCustomAdditionalColumnsCreate() {
+	client := c.TestClient()
+	assert := c.Assert()
+
+	report, _ := client.CreateReport(
+		"shipment",
+		&easypost.Report{
+			StartDate:         c.fixture.ReportStartDate(),
+			EndDate:           c.fixture.ReportEndDate(),
+			AdditionalColumns: []string{"from_name", "from_company"},
+		},
+	)
+
+	assert.Equal(reflect.TypeOf(&easypost.Report{}), reflect.TypeOf(report))
+}
+
 func (c *ClientTests) TestReportPaymentLogRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()


### PR DESCRIPTION
This PR:
- Adds support for specifying `Columns` and `AdditionalColumns` (both lists of strings) in parameters for the `CreateReport` function.

Unfortunately, since the API response does not indicate the columns used for a report, the only way to ensure the report actually includes the columns requested would be to make a live API call, download the generated CSV report and parse its column headers. That is a complex unit test with many points of failure and prevents us from using VCR.

Instead, we simply assume that if no error is thrown during the API call to generate and retrieve the report, that the report contains the correct columns. If it doesn't, that constitutes a server-side error that is out of our control.

This has been end-to-end tested locally. The generated report included the requests columns.