### PR TITLE
add Go version 1.18 in the CI test matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.15", "1.16", "1.17"]
+        go-version: ["1.15", "1.16", "1.17", "1.18"]
     steps:
       - uses: actions/checkout@v2
       - name: use golang ${{ matrix.node-version }}


### PR DESCRIPTION
This PR adds Go version 1.18 in the CI test 