### PR TITLE
add declaration attribute in customs info struct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## NEXT RELEASE
 - Adds custom columns and additional columns to `CreateReport` function
+- Adds `declaration` attribute in Customs Info struct
 
 ## v2.2.0 (2022-03-08)
 

--- a/customs.go
+++ b/customs.go
@@ -20,6 +20,7 @@ type CustomsInfo struct {
 	NonDeliveryOption   string         `json:"non_delivery_option,omitempty"`
 	RestrictionType     string         `json:"restriction_type,omitempty"`
 	CustomsItems        []*CustomsItem `json:"customs_items,omitempty"`
+	Declaration         string         `json:"declaration,omitempty"`
 }
 
 // A CustomsItem object describes goods for international shipment.


### PR DESCRIPTION
Customs Info struct is currently missing the `declaration` attribute.

This PR adds the `declaration` attribute in the Customs Info struct.