### PR TITLE
fix: require API key for requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,13 @@ jobs:
       matrix:
         go-version: ["1.15", "1.16", "1.17", "1.18"]
     steps:
-      - uses: actions/checkout@v3
-      - name: use golang ${{ matrix.node-version }}
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: use golang ${{ matrix.go-version }}
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      - name: install dependencies
-        run: go get -u golang.org/x/lint/golint
       - name: build
-        run: go build .
+        run: make build
       - name: run tests
-        run: cd tests && go test -v
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make test

--- a/tests/address_test.go
+++ b/tests/address_test.go
@@ -11,10 +11,14 @@ func (c *ClientTests) TestAddressCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	address, _ := client.CreateAddress(
+	address, err := client.CreateAddress(
 		c.fixture.BasicAddress(),
 		nil,
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
 	assert.True(strings.HasPrefix(address.ID, "adr_"))
@@ -25,12 +29,16 @@ func (c *ClientTests) TestAddressCreateVerifyStrict() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	address, _ := client.CreateAddress(
+	address, err := client.CreateAddress(
 		c.fixture.BasicAddress(),
 		&easypost.CreateAddressOptions{
 			VerifyStrict: []string{"true"},
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
 	assert.True(strings.HasPrefix(address.ID, "adr_"))
@@ -41,12 +49,20 @@ func (c *ClientTests) TestAddressRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	address, _ := client.CreateAddress(
+	address, err := client.CreateAddress(
 		c.fixture.BasicAddress(),
 		nil,
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedAddress, _ := client.GetAddress(address.ID)
+	retrievedAddress, err := client.GetAddress(address.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(retrievedAddress))
 	assert.Equal(address, retrievedAddress)
@@ -56,11 +72,15 @@ func (c *ClientTests) TestAddressAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	addresses, _ := client.ListAddresses(
+	addresses, err := client.ListAddresses(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.LessOrEqual(len(addresses.Addresses), c.fixture.pageSize())
 	assert.NotNil(addresses.HasMore)
@@ -74,12 +94,16 @@ func (c *ClientTests) TestAddressCreateVerify() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	address, _ := client.CreateAddress(
+	address, err := client.CreateAddress(
 		c.fixture.IncorrectAddressToVerify(),
 		&easypost.CreateAddressOptions{
 			Verify: []string{"delivery"},
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
 	assert.True(strings.HasPrefix(address.ID, "adr_"))
@@ -90,12 +114,16 @@ func (c *ClientTests) TestAddressCreateAndVerify() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	address, _ := client.CreateAndVerifyAddress(
+	address, err := client.CreateAndVerifyAddress(
 		c.fixture.IncorrectAddressToVerify(),
 		&easypost.CreateAddressOptions{
 			Verify: []string{"delivery"},
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
 	assert.True(strings.HasPrefix(address.ID, "adr_"))
@@ -106,12 +134,20 @@ func (c *ClientTests) TestAddressVerify() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	address, _ := client.CreateAddress(
+	address, err := client.CreateAddress(
 		c.fixture.BasicAddress(),
 		nil,
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	verifiedAddress, _ := client.VerifyAddress(address.ID)
+	verifiedAddress, err := client.VerifyAddress(address.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(verifiedAddress))
 	assert.True(strings.HasPrefix(verifiedAddress.ID, "adr_"))

--- a/tests/carrier_account_test.go
+++ b/tests/carrier_account_test.go
@@ -19,13 +19,17 @@ func (c *ClientTests) TestCarrierAccountCreate() {
 	client := c.ProdClient()
 	assert, require := c.Assert(), c.Require()
 
-	carrierAccount, _ := c.GenerateCarrierAccount()
+	carrierAccount, err := c.GenerateCarrierAccount()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.CarrierAccount{}), reflect.TypeOf(carrierAccount))
 	assert.True(strings.HasPrefix(carrierAccount.ID, "ca_"))
 	assert.Equal("UpsAccount", carrierAccount.Type)
 
-	err := client.DeleteCarrierAccount(carrierAccount.ID)
+	err = client.DeleteCarrierAccount(carrierAccount.ID)
 
 	require.NoError(err)
 }
@@ -34,13 +38,22 @@ func (c *ClientTests) TestCarrierAccountRetrieve() {
 	client := c.ProdClient()
 	assert, require := c.Assert(), c.Require()
 
-	carrierAccount, _ := c.GenerateCarrierAccount()
+	carrierAccount, err := c.GenerateCarrierAccount()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedCarrierAccount, _ := client.GetCarrierAccount(carrierAccount.ID)
+	retrievedCarrierAccount, err := client.GetCarrierAccount(carrierAccount.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
+
 	assert.Equal(reflect.TypeOf(&easypost.CarrierAccount{}), reflect.TypeOf(retrievedCarrierAccount))
 	assert.Equal(carrierAccount, retrievedCarrierAccount)
 
-	err := client.DeleteCarrierAccount(carrierAccount.ID)
+	err = client.DeleteCarrierAccount(carrierAccount.ID)
 
 	require.NoError(err)
 }
@@ -49,7 +62,11 @@ func (c *ClientTests) TestCarrierAccountAll() {
 	client := c.ProdClient()
 	assert := c.Assert()
 
-	carrierAccounts, _ := client.ListCarrierAccounts()
+	carrierAccounts, err := client.ListCarrierAccounts()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	for _, carrierAccount := range carrierAccounts {
 		assert.Equal(reflect.TypeOf(&easypost.CarrierAccount{}), reflect.TypeOf(carrierAccount))
@@ -62,17 +79,25 @@ func (c *ClientTests) TestCarrierAccountUpdate() {
 
 	testDescription := "My custom description"
 
-	carrierAccount, _ := c.GenerateCarrierAccount()
+	carrierAccount, err := c.GenerateCarrierAccount()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	carrierAccount.Description = testDescription
 
-	updatedCarrierAccount, _ := client.UpdateCarrierAccount(carrierAccount)
+	updatedCarrierAccount, err := client.UpdateCarrierAccount(carrierAccount)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.CarrierAccount{}), reflect.TypeOf(updatedCarrierAccount))
 	assert.True(strings.HasPrefix(updatedCarrierAccount.ID, "ca_"))
 	assert.Equal(testDescription, updatedCarrierAccount.Description)
 
-	err := client.DeleteCarrierAccount(carrierAccount.ID)
+	err = client.DeleteCarrierAccount(carrierAccount.ID)
 
 	require.NoError(err)
 }
@@ -81,9 +106,13 @@ func (c *ClientTests) TestCarrierAccountDelete() {
 	client := c.ProdClient()
 	require := c.Require()
 
-	carrierAccount, _ := c.GenerateCarrierAccount()
+	carrierAccount, err := c.GenerateCarrierAccount()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	err := client.DeleteCarrierAccount(carrierAccount.ID)
+	err = client.DeleteCarrierAccount(carrierAccount.ID)
 
 	require.NoError(err)
 }
@@ -92,7 +121,11 @@ func (c *ClientTests) TestCarrierAccountTypes() {
 	client := c.ProdClient()
 	assert := c.Assert()
 
-	carriersAccountTypes, _ := client.GetCarrierTypes()
+	carriersAccountTypes, err := client.GetCarrierTypes()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf([]*easypost.CarrierType{}), reflect.TypeOf(carriersAccountTypes))
 }

--- a/tests/cassettes/TestBatchCreateScanForm.yaml
+++ b/tests/cassettes/TestBatchCreateScanForm.yaml
@@ -11,18 +11,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+      - EasyPost/v2 GoClient/2.3.0 Go/go1.18.2 OS/darwin
     url: https://api.easypost.com/v2/batches
     method: POST
   response:
-    body: '{"id":"batch_c3764047be8141c5a52ea37863f15296","object":"Batch","mode":"test","state":"creating","num_shipments":1,"reference":null,"created_at":"2022-03-03T19:08:40Z","updated_at":"2022-03-03T19:08:40Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+    body: '{"id":"batch_fc7040a24ccb4e6489b0c32809b85250","object":"Batch","mode":"test","state":"creating","num_shipments":1,"reference":null,"created_at":"2022-05-16T19:53:59Z","updated_at":"2022-05-16T19:53:59Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"bec26c6ed18b2ad7336d29e80ddfd6ae"
+      - W/"3e65e153e54159d329fa92f46de89011"
       Expires:
       - "0"
       Pragma:
@@ -38,7 +38,7 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 9cb90d0e62211238ff135a20001f1ec9
+      - a65f33796282abd7e78737b80008cee9
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
@@ -46,15 +46,12 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 88c34981dc
-      - intlb2wdc 88c34981dc
-      - extlb1wdc 88c34981dc
-      X-Request-Id:
-      - 0fd2a029-69df-40da-89e6-0035c0cb57f7
+      - intlb1nuq 570dfcbc0a
+      - extlb1nuq c51cdb8bf2
       X-Runtime:
-      - "0.045701"
+      - "0.054324"
       X-Version-Label:
-      - easypost-202203031834-4b65a7cdf4-master
+      - easypost-202205161937-fdfdac8556-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -65,18 +62,18 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
-    url: https://api.easypost.com/v2/batches/batch_c3764047be8141c5a52ea37863f15296/buy
+      - EasyPost/v2 GoClient/2.3.0 Go/go1.18.2 OS/darwin
+    url: https://api.easypost.com/v2/batches/batch_fc7040a24ccb4e6489b0c32809b85250/buy
     method: POST
   response:
-    body: '{"id":"batch_c3764047be8141c5a52ea37863f15296","object":"Batch","mode":"test","state":"created","num_shipments":1,"reference":null,"created_at":"2022-03-03T19:08:40Z","updated_at":"2022-03-03T19:08:40Z","scan_form":null,"shipments":[{"batch_status":"queued_for_purchase","batch_message":null,"reference":null,"tracking_code":null,"id":"shp_34ae61ab1859433494113f3b7f67a65e"}],"status":{"created":1,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+    body: '{"id":"batch_fc7040a24ccb4e6489b0c32809b85250","object":"Batch","mode":"test","state":"created","num_shipments":1,"reference":null,"created_at":"2022-05-16T19:53:59Z","updated_at":"2022-05-16T19:53:59Z","scan_form":null,"shipments":[{"batch_status":"queued_for_purchase","batch_message":null,"reference":null,"tracking_code":null,"id":"shp_02384a29fe074f4a88653cf149505676"}],"status":{"created":1,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"1ca4d081b7dbf2f2be92b562a29b7677"
+      - W/"6c774a46c9fffcb5d1138f1d09e63449"
       Expires:
       - "0"
       Pragma:
@@ -92,23 +89,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 9cb90d0e62211238ff135a20001f1ed6
+      - a65f33796282abd7e78737b80008cf19
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb9nuq
+      - bigweb4nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 88c34981dc
-      - intlb1wdc 88c34981dc
-      - extlb1wdc 88c34981dc
-      X-Request-Id:
-      - 9ec4da3e-0261-4a97-be15-6fc93d7d4af9
+      - intlb1nuq 570dfcbc0a
+      - extlb1nuq c51cdb8bf2
       X-Runtime:
-      - "0.053265"
+      - "0.057158"
       X-Version-Label:
-      - easypost-202203031834-4b65a7cdf4-master
+      - easypost-202205161937-fdfdac8556-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -123,17 +117,18 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
-    url: https://api.easypost.com/v2/batches/batch_c3764047be8141c5a52ea37863f15296/scan_form
+      - EasyPost/v2 GoClient/2.3.0 Go/go1.18.2 OS/darwin
+    url: https://api.easypost.com/v2/batches/batch_fc7040a24ccb4e6489b0c32809b85250/scan_form
     method: POST
   response:
-    body: '{"error":{"code":"SCAN_FORM.BATCH.NOT_PURCHASED","message":"All shipments
-      on the Batch must be purchased before generating a ScanForm.","errors":[]}}'
+    body: '{"id":"batch_fc7040a24ccb4e6489b0c32809b85250","object":"Batch","mode":"test","state":"purchased","num_shipments":1,"reference":null,"created_at":"2022-05-16T19:53:59Z","updated_at":"2022-05-16T19:54:04Z","scan_form":{"id":"sf_7ea69f1504ed4e05be977e8a7882156c","object":"ScanForm","created_at":"2022-05-16T19:54:04Z","updated_at":"2022-05-16T19:54:04Z","tracking_codes":[],"address":null,"status":"creating","message":null,"form_url":null,"form_file_type":null,"batch_id":"batch_fc7040a24ccb4e6489b0c32809b85250","confirmation":null},"shipments":[{"batch_status":"postage_purchased","batch_message":null,"reference":null,"tracking_code":"9400100109361119372119","id":"shp_02384a29fe074f4a88653cf149505676"}],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":1,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
+      Etag:
+      - W/"01d0ed978610ee6cff4c857dd450065b"
       Expires:
       - "0"
       Pragma:
@@ -144,30 +139,29 @@ interactions:
       - max-age=31536000; includeSubDomains; preload
       X-Backend:
       - easypost
+      X-Canary:
+      - direct
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 9cb90d0e62211238ff135a20001f1ee0
+      - a65f33796282abdce78737b80008d26a
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb7nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 88c34981dc
-      - intlb2wdc 88c34981dc
-      - extlb1wdc 88c34981dc
-      X-Request-Id:
-      - aa766e69-2b4e-48a5-9a2b-79b4b3980afe
+      - intlb2nuq 570dfcbc0a
+      - extlb1nuq c51cdb8bf2
       X-Runtime:
-      - "0.047281"
+      - "0.100648"
       X-Version-Label:
-      - easypost-202203031834-4b65a7cdf4-master
+      - easypost-202205161937-fdfdac8556-master
       X-Xss-Protection:
       - 1; mode=block
-    status: 422 Unprocessable Entity
-    code: 422
+    status: 200 OK
+    code: 200
     duration: ""

--- a/tests/cassettes/TestBatchLabel.yaml
+++ b/tests/cassettes/TestBatchLabel.yaml
@@ -11,18 +11,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
+      - EasyPost/v2 GoClient/2.3.0 Go/go1.18.2 OS/darwin
     url: https://api.easypost.com/v2/batches
     method: POST
   response:
-    body: '{"id":"batch_0f12281009214aa9a686fae7f176b06f","object":"Batch","mode":"test","state":"creating","num_shipments":1,"reference":null,"created_at":"2022-03-07T22:07:31Z","updated_at":"2022-03-07T22:07:31Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+    body: '{"id":"batch_beb36aa0c6bc45fb91258e77ab751c14","object":"Batch","mode":"test","state":"creating","num_shipments":1,"reference":null,"created_at":"2022-05-16T19:54:27Z","updated_at":"2022-05-16T19:54:27Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"ba279370cc51fb7d6df6bf97f602ae58"
+      - W/"661fe2da56714f18c9fdeb50e1d26740"
       Expires:
       - "0"
       Pragma:
@@ -38,23 +38,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - d4a3d8d362268222ff103222003ed4c2
+      - a65f33786282abf3e78737b90008e163
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb1nuq
+      - bigweb2nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 88c34981dc
-      - intlb2wdc 88c34981dc
-      - extlb3wdc 88c34981dc
-      X-Request-Id:
-      - 60260ad8-b9c0-49c7-b0af-5a0967f40ae4
+      - intlb2nuq 570dfcbc0a
+      - extlb1nuq c51cdb8bf2
       X-Runtime:
-      - "0.064162"
+      - "0.040356"
       X-Version-Label:
-      - easypost-202203042109-ebc16e3e74-master
+      - easypost-202205161937-fdfdac8556-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -65,18 +62,18 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
-    url: https://api.easypost.com/v2/batches/batch_0f12281009214aa9a686fae7f176b06f/buy
+      - EasyPost/v2 GoClient/2.3.0 Go/go1.18.2 OS/darwin
+    url: https://api.easypost.com/v2/batches/batch_beb36aa0c6bc45fb91258e77ab751c14/buy
     method: POST
   response:
-    body: '{"id":"batch_0f12281009214aa9a686fae7f176b06f","object":"Batch","mode":"test","state":"created","num_shipments":1,"reference":null,"created_at":"2022-03-07T22:07:31Z","updated_at":"2022-03-07T22:07:31Z","scan_form":null,"shipments":[{"batch_status":"queued_for_purchase","batch_message":null,"reference":null,"tracking_code":null,"id":"shp_bac53d82cba74b83b4c731ac43be4f95"}],"status":{"created":1,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+    body: '{"id":"batch_beb36aa0c6bc45fb91258e77ab751c14","object":"Batch","mode":"test","state":"created","num_shipments":1,"reference":null,"created_at":"2022-05-16T19:54:27Z","updated_at":"2022-05-16T19:54:27Z","scan_form":null,"shipments":[{"batch_status":"queued_for_purchase","batch_message":null,"reference":null,"tracking_code":null,"id":"shp_d6c68e90f7f84c5dbe9bd6c248eee1c5"}],"status":{"created":1,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"81075ab4ed4b567f838baae2fb17b8e8"
+      - W/"e2716725a64a1a6ca49354b2e0c7b290"
       Expires:
       - "0"
       Pragma:
@@ -92,23 +89,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - d4a3d8d362268223ff103222003ed4f1
+      - a65f33786282abf3e78737b90008e174
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb1nuq
+      - bigweb8nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 88c34981dc
-      - intlb1wdc 88c34981dc
-      - extlb3wdc 88c34981dc
-      X-Request-Id:
-      - 65d2e6ab-61c9-4fd7-a195-62e1fa99f150
+      - intlb1nuq 570dfcbc0a
+      - extlb1nuq c51cdb8bf2
       X-Runtime:
-      - "0.105543"
+      - "0.052973"
       X-Version-Label:
-      - easypost-202203042109-ebc16e3e74-master
+      - easypost-202205161937-fdfdac8556-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -123,18 +117,18 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - EasyPost/v2 GoClient/2.0.1 Go/go1.17.5 OS/darwin
-    url: https://api.easypost.com/v2/batches/batch_0f12281009214aa9a686fae7f176b06f/label
+      - EasyPost/v2 GoClient/2.3.0 Go/go1.18.2 OS/darwin
+    url: https://api.easypost.com/v2/batches/batch_beb36aa0c6bc45fb91258e77ab751c14/label
     method: POST
   response:
-    body: '{"id":"batch_0f12281009214aa9a686fae7f176b06f","object":"Batch","mode":"test","state":"label_generating","num_shipments":1,"reference":null,"created_at":"2022-03-07T22:07:31Z","updated_at":"2022-03-07T22:07:36Z","scan_form":null,"shipments":[{"batch_status":"postage_purchased","batch_message":null,"reference":null,"tracking_code":"9400100109361110241148","id":"shp_bac53d82cba74b83b4c731ac43be4f95"}],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":1,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+    body: '{"id":"batch_beb36aa0c6bc45fb91258e77ab751c14","object":"Batch","mode":"test","state":"label_generating","num_shipments":1,"reference":null,"created_at":"2022-05-16T19:54:27Z","updated_at":"2022-05-16T19:54:33Z","scan_form":null,"shipments":[{"batch_status":"postage_purchased","batch_message":null,"reference":null,"tracking_code":"9400100109361119372188","id":"shp_d6c68e90f7f84c5dbe9bd6c248eee1c5"}],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":1,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"5b27ec6f1ae8480f8515ab9508de686c"
+      - W/"8a450d9e79e87308367fcdb6a4692b7e"
       Expires:
       - "0"
       Pragma:
@@ -150,23 +144,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - d4a3d8d362268228ff103222003ed6b2
+      - a65f33786282abf9e78737b90008e482
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb8nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 88c34981dc
-      - intlb1wdc 88c34981dc
-      - extlb3wdc 88c34981dc
-      X-Request-Id:
-      - 2acac1d5-7607-4850-a545-74877f0b658d
+      - intlb2nuq 570dfcbc0a
+      - extlb1nuq c51cdb8bf2
       X-Runtime:
-      - "0.040596"
+      - "0.040894"
       X-Version-Label:
-      - easypost-202203042109-ebc16e3e74-master
+      - easypost-202205161937-fdfdac8556-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/tests/customs_info_test.go
+++ b/tests/customs_info_test.go
@@ -11,7 +11,11 @@ func (c *ClientTests) TestCustomsInfoCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	customsInfo, _ := client.CreateCustomsInfo(c.fixture.BasicCustomsInfo())
+	customsInfo, err := client.CreateCustomsInfo(c.fixture.BasicCustomsInfo())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.CustomsInfo{}), reflect.TypeOf(customsInfo))
 	assert.True(strings.HasPrefix(customsInfo.ID, "cstinfo_"))
@@ -22,9 +26,17 @@ func (c *ClientTests) TestCustomsInfoRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	customsInfo, _ := client.CreateCustomsInfo(c.fixture.BasicCustomsInfo())
+	customsInfo, err := client.CreateCustomsInfo(c.fixture.BasicCustomsInfo())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedCustomsInfo, _ := client.GetCustomsInfo(customsInfo.ID)
+	retrievedCustomsInfo, err := client.GetCustomsInfo(customsInfo.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.CustomsInfo{}), reflect.TypeOf(retrievedCustomsInfo))
 	assert.Equal(customsInfo, retrievedCustomsInfo)

--- a/tests/customs_item_test.go
+++ b/tests/customs_item_test.go
@@ -11,7 +11,11 @@ func (c *ClientTests) TestCustomsItemCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	customsItem, _ := client.CreateCustomsItem(c.fixture.BasicCustomsItem())
+	customsItem, err := client.CreateCustomsItem(c.fixture.BasicCustomsItem())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.CustomsItem{}), reflect.TypeOf(customsItem))
 	assert.True(strings.HasPrefix(customsItem.ID, "cstitem_"))
@@ -22,9 +26,17 @@ func (c *ClientTests) TestCustomsItemRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	customsItem, _ := client.CreateCustomsItem(c.fixture.BasicCustomsItem())
+	customsItem, err := client.CreateCustomsItem(c.fixture.BasicCustomsItem())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedCustomsItem, _ := client.GetCustomsItem(customsItem.ID)
+	retrievedCustomsItem, err := client.GetCustomsItem(customsItem.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.CustomsItem{}), reflect.TypeOf(retrievedCustomsItem))
 	assert.Equal(customsItem, retrievedCustomsItem)

--- a/tests/event_test.go
+++ b/tests/event_test.go
@@ -1,20 +1,25 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go/v2"
 	"reflect"
 	"strings"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestEventAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	events, _ := client.ListEvents(
+	events, err := client.ListEvents(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	eventsList := events.Events
 
@@ -29,13 +34,22 @@ func (c *ClientTests) TestEventRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	events, _ := client.ListEvents(
+	events, err := client.ListEvents(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	event, _ := client.GetEvent(events.Events[0].ID)
+	event, err := client.GetEvent(events.Events[0].ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
+
 	assert.Equal(reflect.TypeOf(&easypost.Event{}), reflect.TypeOf(event))
 	assert.True(strings.HasPrefix(event.ID, "evt_"))
 }

--- a/tests/insurance_test.go
+++ b/tests/insurance_test.go
@@ -11,12 +11,20 @@ func (c *ClientTests) TestInsuranceCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	insuranceData := c.fixture.BasicInsurance()
 	insuranceData.TrackingCode = shipment.TrackingCode
 
-	insurance, _ := client.CreateInsurance(insuranceData)
+	insurance, err := client.CreateInsurance(insuranceData)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Insurance{}), reflect.TypeOf(insurance))
 	assert.True(strings.HasPrefix(insurance.ID, "ins_"))
@@ -27,14 +35,26 @@ func (c *ClientTests) TestInsuranceRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	insuranceData := c.fixture.BasicInsurance()
 	insuranceData.TrackingCode = shipment.TrackingCode
 
-	insurance, _ := client.CreateInsurance(insuranceData)
+	insurance, err := client.CreateInsurance(insuranceData)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedInsurance, _ := client.GetInsurance(insurance.ID)
+	retrievedInsurance, err := client.GetInsurance(insurance.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Insurance{}), reflect.TypeOf(retrievedInsurance))
 	assert.Equal(insurance, retrievedInsurance)
@@ -44,11 +64,15 @@ func (c *ClientTests) TestInsuranceAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	insurances, _ := client.ListInsurances(
+	insurances, err := client.ListInsurances(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	insurancesList := insurances.Insurances
 

--- a/tests/order_test.go
+++ b/tests/order_test.go
@@ -11,7 +11,11 @@ func (c *ClientTests) TestOrderCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	order, _ := client.CreateOrder(c.fixture.BasicOrder())
+	order, err := client.CreateOrder(c.fixture.BasicOrder())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Order{}), reflect.TypeOf(order))
 	assert.True(strings.HasPrefix(order.ID, "order_"))
@@ -22,9 +26,17 @@ func (c *ClientTests) TestOrderRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	order, _ := client.CreateOrder(c.fixture.BasicOrder())
+	order, err := client.CreateOrder(c.fixture.BasicOrder())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedOrder, _ := client.GetOrder(order.ID)
+	retrievedOrder, err := client.GetOrder(order.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Order{}), reflect.TypeOf(retrievedOrder))
 	assert.Equal(order.ID, retrievedOrder.ID)
@@ -34,9 +46,17 @@ func (c *ClientTests) TestOrderGetRates() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	order, _ := client.CreateOrder(c.fixture.BasicOrder())
+	order, err := client.CreateOrder(c.fixture.BasicOrder())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	rates, _ := client.GetOrderRates(order.ID)
+	rates, err := client.GetOrderRates(order.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	ratesList := rates.Rates
 
@@ -50,9 +70,17 @@ func (c *ClientTests) TestOrderBuyRate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	order, _ := client.CreateOrder(c.fixture.BasicOrder())
+	order, err := client.CreateOrder(c.fixture.BasicOrder())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	boughtOrder, _ := client.BuyOrder(order.ID, c.fixture.USPS(), c.fixture.USPSService())
+	boughtOrder, err := client.BuyOrder(order.ID, c.fixture.USPS(), c.fixture.USPSService())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	shipmentsList := boughtOrder.Shipments
 

--- a/tests/parcel_test.go
+++ b/tests/parcel_test.go
@@ -1,16 +1,21 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go/v2"
 	"reflect"
 	"strings"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestParcelCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	parcel, _ := client.CreateParcel(c.fixture.BasicParcel())
+	parcel, err := client.CreateParcel(c.fixture.BasicParcel())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Parcel{}), reflect.TypeOf(parcel))
 	assert.True(strings.HasPrefix(parcel.ID, "prcl_"))
@@ -21,9 +26,17 @@ func (c *ClientTests) TestParcelRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	parcel, _ := client.CreateParcel(c.fixture.BasicParcel())
+	parcel, err := client.CreateParcel(c.fixture.BasicParcel())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedParcel, _ := client.GetParcel(parcel.ID)
+	retrievedParcel, err := client.GetParcel(parcel.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Parcel{}), reflect.TypeOf(retrievedParcel))
 	assert.Equal(parcel, retrievedParcel)

--- a/tests/pickup_test.go
+++ b/tests/pickup_test.go
@@ -11,12 +11,20 @@ func (c *ClientTests) TestPickupCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	pickupData := c.fixture.BasicPickup()
 	pickupData.Shipment = shipment
 
-	pickup, _ := client.CreatePickup(pickupData)
+	pickup, err := client.CreatePickup(pickupData)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Pickup{}), reflect.TypeOf(pickup))
 	assert.True(strings.HasPrefix(pickup.ID, "pickup_"))
@@ -27,14 +35,26 @@ func (c *ClientTests) TestPickupRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	pickupData := c.fixture.BasicPickup()
 	pickupData.Shipment = shipment
 
-	pickup, _ := client.CreatePickup(pickupData)
+	pickup, err := client.CreatePickup(pickupData)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievePickup, _ := client.GetPickup(pickup.ID)
+	retrievePickup, err := client.GetPickup(pickup.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Pickup{}), reflect.TypeOf(retrievePickup))
 	assert.Equal(pickup, retrievePickup)
@@ -44,20 +64,32 @@ func (c *ClientTests) TestPickupBuy() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	pickupData := c.fixture.BasicPickup()
 	pickupData.Shipment = shipment
 
-	pickup, _ := client.CreatePickup(pickupData)
+	pickup, err := client.CreatePickup(pickupData)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	boughtPickup, _ := client.BuyPickup(
+	boughtPickup, err := client.BuyPickup(
 		pickup.ID,
 		&easypost.PickupRate{
 			Carrier: c.fixture.USPS(),
 			Service: c.fixture.PickupService(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Pickup{}), reflect.TypeOf(boughtPickup))
 	assert.True(strings.HasPrefix(boughtPickup.ID, "pickup_"))
@@ -69,22 +101,38 @@ func (c *ClientTests) TestPickupCancel() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	pickupData := c.fixture.BasicPickup()
 	pickupData.Shipment = shipment
 
-	pickup, _ := client.CreatePickup(pickupData)
+	pickup, err := client.CreatePickup(pickupData)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	boughtPickup, _ := client.BuyPickup(
+	boughtPickup, err := client.BuyPickup(
 		pickup.ID,
 		&easypost.PickupRate{
 			Carrier: c.fixture.USPS(),
 			Service: c.fixture.PickupService(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	cancelledPickup, _ := client.CancelPickup(boughtPickup.ID)
+	cancelledPickup, err := client.CancelPickup(boughtPickup.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Pickup{}), reflect.TypeOf(cancelledPickup))
 	assert.True(strings.HasPrefix(cancelledPickup.ID, "pickup_"))

--- a/tests/rate_test.go
+++ b/tests/rate_test.go
@@ -1,18 +1,27 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go/v2"
 	"reflect"
 	"strings"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestRateRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.BasicShipment())
+	shipment, err := client.CreateShipment(c.fixture.BasicShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	rate, _ := client.GetRate(shipment.Rates[0].ID)
+	rate, err := client.GetRate(shipment.Rates[0].ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Rate{}), reflect.TypeOf(rate))
 	assert.True(strings.HasPrefix(rate.ID, "rate_"))

--- a/tests/refund_test.go
+++ b/tests/refund_test.go
@@ -1,25 +1,38 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go/v2"
 	"reflect"
 	"strings"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestRefundCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedShipment, _ := client.GetShipment(shipment.ID) // We need to retrieve the shipment so that the tracking_code has time to populate
+	retrievedShipment, err := client.GetShipment(shipment.ID) // We need to retrieve the shipment so that the tracking_code has time to populate
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	refund, _ := client.CreateRefund(
+	refund, err := client.CreateRefund(
 		map[string]interface{}{
 			"carrier":        "USPS",
 			"tracking_codes": retrievedShipment.TrackingCode,
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.True(strings.HasPrefix(refund[0].ID, "rfnd_"))
 	assert.Equal("submitted", refund[0].Status)
@@ -29,11 +42,15 @@ func (c *ClientTests) TestRefundAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	refunds, _ := client.ListRefunds(
+	refunds, err := client.ListRefunds(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	refundsList := refunds.Refunds
 
@@ -48,13 +65,21 @@ func (c *ClientTests) TestRefundRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	refunds, _ := client.ListRefunds(
+	refunds, err := client.ListRefunds(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedRefund, _ := client.GetRefund(refunds.Refunds[0].ID)
+	retrievedRefund, err := client.GetRefund(refunds.Refunds[0].ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Refund{}), reflect.TypeOf(retrievedRefund))
 	assert.Equal(refunds.Refunds[0].ID, retrievedRefund.ID)

--- a/tests/report_test.go
+++ b/tests/report_test.go
@@ -11,13 +11,17 @@ func (c *ClientTests) TestReportCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	report, _ := client.CreateReport(
+	report, err := client.CreateReport(
 		c.fixture.ReportType(),
 		&easypost.Report{
 			StartDate: c.fixture.ReportDate(),
 			EndDate:   c.fixture.ReportDate(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Report{}), reflect.TypeOf(report))
 	assert.True(strings.HasPrefix(report.ID, "shprep_"))
@@ -27,7 +31,7 @@ func (c *ClientTests) TestReportCustomColumnsCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	report, _ := client.CreateReport(
+	report, err := client.CreateReport(
 		c.fixture.ReportType(),
 		&easypost.Report{
 			StartDate: c.fixture.ReportDate(),
@@ -35,6 +39,10 @@ func (c *ClientTests) TestReportCustomColumnsCreate() {
 			Columns:   []string{"usps_zone"},
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	// verify parameters by checking VCR cassette for correct URL
 	// Some reports take a long time to generate, so we won't be able to consistently pull the report
@@ -48,7 +56,7 @@ func (c *ClientTests) TestReportCustomAdditionalColumnsCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	report, _ := client.CreateReport(
+	report, err := client.CreateReport(
 		c.fixture.ReportType(),
 		&easypost.Report{
 			StartDate:         c.fixture.ReportDate(),
@@ -56,6 +64,10 @@ func (c *ClientTests) TestReportCustomAdditionalColumnsCreate() {
 			AdditionalColumns: []string{"from_name", "from_company"},
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	// verify parameters by checking VCR cassette for correct URL
 	// Some reports take a long time to generate, so we won't be able to consistently pull the report
@@ -69,15 +81,23 @@ func (c *ClientTests) TestReportRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	report, _ := client.CreateReport(
+	report, err := client.CreateReport(
 		c.fixture.ReportType(),
 		&easypost.Report{
 			StartDate: c.fixture.ReportDate(),
 			EndDate:   c.fixture.ReportDate(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedReport, _ := client.GetReport(c.fixture.ReportType(), report.ID)
+	retrievedReport, err := client.GetReport(c.fixture.ReportType(), report.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Report{}), reflect.TypeOf(retrievedReport))
 	assert.Equal(report.StartDate, retrievedReport.StartDate)
@@ -88,12 +108,16 @@ func (c *ClientTests) TestReportAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	reports, _ := client.ListReports(
+	reports, err := client.ListReports(
 		c.fixture.ReportType(),
 		&easypost.ListReportsOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	reportsList := reports.Reports
 

--- a/tests/scan_form_test.go
+++ b/tests/scan_form_test.go
@@ -1,18 +1,27 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go/v2"
 	"reflect"
 	"strings"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestScanFormCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	scanform, _ := client.CreateScanForm(shipment.ID)
+	scanform, err := client.CreateScanForm(shipment.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.ScanForm{}), reflect.TypeOf(scanform))
 	assert.True(strings.HasPrefix(scanform.ID, "sf_"))
@@ -22,11 +31,23 @@ func (c *ClientTests) TestScanFormRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	scanform, _ := client.CreateScanForm(shipment.ID)
+	scanform, err := client.CreateScanForm(shipment.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedScanform, _ := client.GetScanForm(scanform.ID)
+	retrievedScanform, err := client.GetScanForm(scanform.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.ScanForm{}), reflect.TypeOf(retrievedScanform))
 	assert.Equal(scanform, retrievedScanform)
@@ -36,11 +57,15 @@ func (c *ClientTests) TestScanFormAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	scanforms, _ := client.ListScanForms(
+	scanforms, err := client.ListScanForms(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	scanformsList := scanforms.ScanForms
 

--- a/tests/shipment_test.go
+++ b/tests/shipment_test.go
@@ -11,7 +11,11 @@ func (c *ClientTests) TestShipmentCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.FullShipment())
+	shipment, err := client.CreateShipment(c.fixture.FullShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(shipment))
 	assert.True(strings.HasPrefix(shipment.ID, "shp_"))
@@ -25,9 +29,17 @@ func (c *ClientTests) TestShipmentRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.FullShipment())
+	shipment, err := client.CreateShipment(c.fixture.FullShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedShipment, _ := client.GetShipment(shipment.ID)
+	retrievedShipment, err := client.GetShipment(shipment.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(retrievedShipment))
 	assert.Equal(shipment, retrievedShipment)
@@ -37,11 +49,15 @@ func (c *ClientTests) TestShipmentAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipments, _ := client.ListShipments(
+	shipments, err := client.ListShipments(
 		&easypost.ListShipmentsOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	shipmentsList := shipments.Shipments
 
@@ -56,11 +72,23 @@ func (c *ClientTests) TestShipmentBuy() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.FullShipment())
+	shipment, err := client.CreateShipment(c.fixture.FullShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	lowestRate, _ := client.LowestRate(shipment)
+	lowestRate, err := client.LowestRate(shipment)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	boughtShipment, _ := client.BuyShipment(shipment.ID, &lowestRate, "")
+	boughtShipment, err := client.BuyShipment(shipment.ID, &lowestRate, "")
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.NotNil(boughtShipment.PostageLabel)
 }
@@ -69,9 +97,17 @@ func (c *ClientTests) TestShipmentRegenerateRates() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.FullShipment())
+	shipment, err := client.CreateShipment(c.fixture.FullShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	rates, _ := client.RerateShipment(shipment.ID)
+	rates, err := client.RerateShipment(shipment.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf([]*easypost.Rate{}), reflect.TypeOf(rates))
 	for _, rate := range rates {
@@ -83,9 +119,17 @@ func (c *ClientTests) TestShipmentConvertLabel() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	shipmentWithNewLabel, _ := client.GetShipmentLabel(shipment.ID, "ZPL")
+	shipmentWithNewLabel, err := client.GetShipmentLabel(shipment.ID, "ZPL")
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.NotNil(shipmentWithNewLabel.PostageLabel.LabelZPLURL)
 }
@@ -100,9 +144,17 @@ func (c *ClientTests) TestShipmentInsure() {
 	// Set to 0 so USPS doesn't insure this automatically and we can insure the shipment manually
 	shipmentData.Insurance = "0"
 
-	shipment, _ := client.CreateShipment(shipmentData)
+	shipment, err := client.CreateShipment(shipmentData)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	insuredShipment, _ := client.InsureShipment(shipment.ID, "100")
+	insuredShipment, err := client.InsureShipment(shipment.ID, "100")
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal("100.00", insuredShipment.Insurance)
 }
@@ -114,9 +166,17 @@ func (c *ClientTests) TestShipmentRefund() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	refundShipment, _ := client.RefundShipment(shipment.ID)
+	refundShipment, err := client.RefundShipment(shipment.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal("submitted", refundShipment.RefundStatus)
 }
@@ -125,11 +185,19 @@ func (c *ClientTests) TestShipmentSmartrate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	shipment, _ := client.CreateShipment(c.fixture.BasicShipment())
+	shipment, err := client.CreateShipment(c.fixture.BasicShipment())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.NotNil(shipment.Rates)
 
-	smartrates, _ := client.GetShipmentSmartrates(shipment.ID)
+	smartrates, err := client.GetShipmentSmartrates(shipment.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(shipment.Rates[0].ID, smartrates[0].ID)
 	assert.NotNil(smartrates[0].TimeInTransit.Percentile50)
@@ -152,7 +220,11 @@ func (c *ClientTests) TestShipmentCreateEmptyObjects() {
 	shipmentData.CustomsInfo = &easypost.CustomsInfo{}
 	shipmentData.CustomsInfo.CustomsItems = []*easypost.CustomsItem{}
 
-	shipment, _ := client.CreateShipment(shipmentData)
+	shipment, err := client.CreateShipment(shipmentData)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(shipment))
 	assert.True(strings.HasPrefix(shipment.ID, "shp_"))
@@ -169,7 +241,11 @@ func (c *ClientTests) TestShipmentCreateTaxIdentifier() {
 	shipmentData := c.fixture.BasicShipment()
 	shipmentData.TaxIdentifiers = []*easypost.TaxIdentifier{c.fixture.TaxIdentifier()}
 
-	shipment, _ := client.CreateShipment(shipmentData)
+	shipment, err := client.CreateShipment(shipmentData)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(shipment))
 	assert.True(strings.HasPrefix(shipment.ID, "shp_"))
@@ -180,17 +256,33 @@ func (c *ClientTests) TestShipmentCreateWithIds() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	fromAddress, _ := client.CreateAddress(c.fixture.BasicAddress(), nil)
-	toAddress, _ := client.CreateAddress(c.fixture.BasicAddress(), nil)
-	parcel, _ := client.CreateParcel(c.fixture.BasicParcel())
+	fromAddress, err := client.CreateAddress(c.fixture.BasicAddress(), nil)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
+	toAddress, err := client.CreateAddress(c.fixture.BasicAddress(), nil)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
+	parcel, err := client.CreateParcel(c.fixture.BasicParcel())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	shipment, _ := client.CreateShipment(
+	shipment, err := client.CreateShipment(
 		&easypost.Shipment{
 			FromAddress: &easypost.Address{ID: fromAddress.ID},
 			ToAddress:   &easypost.Address{ID: toAddress.ID},
 			Parcel:      &easypost.Parcel{ID: parcel.ID},
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(shipment))
 	assert.True(strings.HasPrefix(shipment.ID, "shp_"))

--- a/tests/tracker_test.go
+++ b/tests/tracker_test.go
@@ -1,21 +1,26 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go/v2"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/EasyPost/easypost-go/v2"
 )
 
 func (c *ClientTests) TestTrackerCreate() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	tracker, _ := client.CreateTracker(
+	tracker, err := client.CreateTracker(
 		&easypost.CreateTrackerOptions{
 			TrackingCode: "EZ1000000001",
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Tracker{}), reflect.TypeOf(tracker))
 	assert.True(strings.HasPrefix(tracker.ID, "trk_"))
@@ -26,14 +31,22 @@ func (c *ClientTests) TestTrackerRetrieve() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	tracker, _ := client.CreateTracker(
+	tracker, err := client.CreateTracker(
 		&easypost.CreateTrackerOptions{
 			TrackingCode: "EZ1000000001",
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	// Test trackers cycle through their "dummy" statuses automatically, the created and retrieved objects may differ
-	retrievedTracker, _ := client.GetTracker(tracker.ID)
+	retrievedTracker, err := client.GetTracker(tracker.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Tracker{}), reflect.TypeOf(retrievedTracker))
 	assert.Equal(tracker.ID, retrievedTracker.ID)
@@ -43,11 +56,15 @@ func (c *ClientTests) TestTrackerAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	trackers, _ := client.ListTrackers(
+	trackers, err := client.ListTrackers(
 		&easypost.ListTrackersOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	trackersList := trackers.Trackers
 
@@ -72,6 +89,10 @@ func (c *ClientTests) TestTrackerCreateList() {
 	}
 
 	response, err := client.CreateTrackerList(trackingCodeParam)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	// This endpoint returns nothing so we assert the function returns true
 	assert.True(response)

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -15,11 +15,15 @@ func (c *ClientTests) TestUserCreate() {
 
 	userName := "Test User"
 
-	user, _ := client.CreateUser(
+	user, err := client.CreateUser(
 		&easypost.UserOptions{
 			Name: &userName,
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.User{}), reflect.TypeOf(user))
 	assert.True(strings.HasPrefix(user.ID, "user_"))
@@ -30,9 +34,17 @@ func (c *ClientTests) TestUserRetrieve() {
 	client := c.ProdClient()
 	assert := c.Assert()
 
-	authenticatedUser, _ := client.RetrieveMe()
+	authenticatedUser, err := client.RetrieveMe()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedUser, _ := client.GetUser(authenticatedUser.Children[0].ID)
+	retrievedUser, err := client.GetUser(authenticatedUser.Children[0].ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.User{}), reflect.TypeOf(retrievedUser))
 	assert.True(strings.HasPrefix(retrievedUser.ID, "user_"))
@@ -42,7 +54,11 @@ func (c *ClientTests) TestUserRetrieveMe() {
 	client := c.ProdClient()
 	assert := c.Assert()
 
-	user, _ := client.RetrieveMe()
+	user, err := client.RetrieveMe()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.User{}), reflect.TypeOf(user))
 	assert.True(strings.HasPrefix(user.ID, "user_"))
@@ -52,16 +68,24 @@ func (c *ClientTests) TestUserUpdate() {
 	client := c.ProdClient()
 	assert := c.Assert()
 
-	user, _ := client.RetrieveMe()
+	user, err := client.RetrieveMe()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	test_phone := "5555555555"
 
-	updatedUser, _ := client.UpdateUser(
+	updatedUser, err := client.UpdateUser(
 		&easypost.UserOptions{
 			ID:          user.ID,
 			PhoneNumber: &test_phone,
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.User{}), reflect.TypeOf(updatedUser))
 	assert.True(strings.HasPrefix(updatedUser.ID, "user_"))
@@ -74,14 +98,22 @@ func (c *ClientTests) TestUserUpdateBrand() {
 
 	color := "#123456"
 
-	user, _ := client.RetrieveMe()
+	user, err := client.RetrieveMe()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	brand, _ := client.UpdateBrand(
+	brand, err := client.UpdateBrand(
 		map[string]interface{}{
 			"color": color,
 		},
 		user.ID,
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Brand{}), reflect.TypeOf(brand))
 	assert.True(strings.HasPrefix(brand.ID, "brd_"))
@@ -95,13 +127,21 @@ func (c *ClientTests) TestUserDelete() {
 
 	userName := "Test User"
 
-	user, _ := client.CreateUser(
+	user, err := client.CreateUser(
 		&easypost.UserOptions{
 			Name: &userName,
 		},
 	)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	err := client.DeleteUser(user.ID)
+	err = client.DeleteUser(user.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	require.NoError(err)
 }
@@ -111,7 +151,11 @@ func (c *ClientTests) TestUserApiKeysAll() {
 	client := c.ProdClient()
 	assert := c.Assert()
 
-	apiKeys, _ := client.GetAPIKeys()
+	apiKeys, err := client.GetAPIKeys()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.NotNil(apiKeys)
 }

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -11,13 +11,21 @@ func (c *ClientTests) TestWebhookCreate() {
 	client := c.TestClient()
 	assert, require := c.Assert(), c.Require()
 
-	webhook, _ := client.CreateWebhook(c.fixture.WebhookUrl())
+	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(webhook))
 	assert.True(strings.HasPrefix(webhook.ID, "hook_"))
 	assert.Equal(c.fixture.WebhookUrl(), webhook.URL)
 
-	err := client.DeleteWebhook(webhook.ID) // we are deleting the webhook here so we don't keep sending events to a dead webhook.
+	err = client.DeleteWebhook(webhook.ID) // we are deleting the webhook here so we don't keep sending events to a dead webhook.
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	require.NoError(err)
 }
@@ -26,14 +34,26 @@ func (c *ClientTests) TestWebhookRetrieve() {
 	client := c.TestClient()
 	assert, require := c.Assert(), c.Require()
 
-	webhook, _ := client.CreateWebhook(c.fixture.WebhookUrl())
+	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
-	retrievedWebhook, _ := client.GetWebhook(webhook.ID)
+	retrievedWebhook, err := client.GetWebhook(webhook.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(retrievedWebhook))
 	assert.Equal(webhook, retrievedWebhook)
 
-	err := client.DeleteWebhook(retrievedWebhook.ID) // we are deleting the webhook here, so we don't keep sending events to a dead webhook.
+	err = client.DeleteWebhook(retrievedWebhook.ID) // we are deleting the webhook here, so we don't keep sending events to a dead webhook.
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	require.NoError(err)
 }
@@ -42,7 +62,11 @@ func (c *ClientTests) TestWebhookAll() {
 	client := c.TestClient()
 	assert := c.Assert()
 
-	webhooks, _ := client.ListWebhooks()
+	webhooks, err := client.ListWebhooks()
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.LessOrEqual(len(webhooks), c.fixture.pageSize())
 	for _, webhook := range webhooks {
@@ -54,13 +78,21 @@ func (c *ClientTests) TestWebhookDelete() {
 	client := c.TestClient()
 	assert, require := c.Assert(), c.Require()
 
-	webhook, _ := client.CreateWebhook(c.fixture.WebhookUrl())
+	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(webhook))
 	assert.True(strings.HasPrefix(webhook.ID, "hook_"))
 	assert.Equal(c.fixture.WebhookUrl(), webhook.URL)
 
-	err := client.DeleteWebhook(webhook.ID)
+	err = client.DeleteWebhook(webhook.ID)
+	if err != nil {
+		c.T().Error(err)
+		return
+	}
 
 	// This endpoint/method does not return anything, just make sure the request doesn't fail
 	require.NoError(err)


### PR DESCRIPTION
# Description

- Requires an API key before making a live API call
- Adds error checking into every test, otherwise a panic is thrown due to `test panicked: runtime error: invalid memory address or nil pointer dereference` when no API key is present for instance (this led to finding that one of the cassettes was recorded with errors and did not complete successfully. This should help debug Go tests moving forward much easier.)
- Adds dynamic wait periods for batch tests that require them based on the presence of the cassette

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- [x] A/B tested that the error is thrown when no API keys are present and that no error is thrown when they are
- [x] Re-recorded batch cassettes that had hidden errors

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
