### PR TITLE
refactor: consolidate struct location to top of files

### DIFF
--- a/address.go
+++ b/address.go
@@ -79,6 +79,21 @@ type AddressVerifyResponse struct {
 	Address *Address `json:"address,omitempty"`
 }
 
+// ListAddressResult holds the results from the list addresses API.
+type ListAddressResult struct {
+	Addresses []*Address `json:"addresses,omitempty"`
+	// HasMore indicates if there are more responses to be fetched. If True,
+	// additional responses can be fetched by updating the ListAddressOptions
+	// parameter's AfterID field with the ID of the last item in this object's
+	// Addresses field.
+	HasMore bool `json:"has_more,omitempty"`
+}
+
+// For some reason, the verify API returns the address in a nested dictionary.
+type verifyAddressResponse struct {
+	Address **Address `json:"address,omitempty"`
+}
+
 // CreateAddress submits a request to create a new address, and returns the
 // result.
 //	c := easypost.New(MyEasyPostAPIKey)
@@ -109,16 +124,6 @@ func (c *Client) CreateAddressWithContext(ctx context.Context, in *Address, opts
 	return
 }
 
-// ListAddressResult holds the results from the list addresses API.
-type ListAddressResult struct {
-	Addresses []*Address `json:"addresses,omitempty"`
-	// HasMore indicates if there are more responses to be fetched. If True,
-	// additional responses can be fetched by updating the ListAddressOptions
-	// parameter's AfterID field with the ID of the last item in this object's
-	// Addresses field.
-	HasMore bool `json:"has_more,omitempty"`
-}
-
 // ListAddresses provides a paginated result of Address objects.
 func (c *Client) ListAddresses(opts *ListOptions) (out *ListAddressResult, err error) {
 	return c.ListAddressesWithContext(context.Background(), opts)
@@ -129,11 +134,6 @@ func (c *Client) ListAddresses(opts *ListOptions) (out *ListAddressResult, err e
 func (c *Client) ListAddressesWithContext(ctx context.Context, opts *ListOptions) (out *ListAddressResult, err error) {
 	err = c.do(ctx, http.MethodGet, "addresses", c.convertOptsToURLValues(opts), &out)
 	return
-}
-
-// For some reason, the verify API returns the address in a nested dictionary.
-type verifyAddressResponse struct {
-	Address **Address `json:"address,omitempty"`
 }
 
 // VerifyAddress performs address verification.

--- a/batch.go
+++ b/batch.go
@@ -36,6 +36,16 @@ type batchRequest struct {
 	Batch *Batch `json:"batch,omitempty"`
 }
 
+// ListBatchesResult holds the results from the list insurances API.
+type ListBatchesResult struct {
+	Batch []*Batch `json:"batches,omitempty"`
+	// HasMore indicates if there are more responses to be fetched. If True,
+	// additional responses can be fetched by updating the ListInsurancesOptions
+	// parameter's AfterID field with the ID of the last item in this object's
+	// Insurances field.
+	HasMore bool `json:"has_more,omitempty"`
+}
+
 // CreateBatch creates a new batch of shipments. It optionally accepts one or
 // more shipments to add to the new batch. If successful, a new batch object is
 // returned.
@@ -73,16 +83,6 @@ func (c *Client) CreateAndBuyBatchWithContext(ctx context.Context, in ...*Shipme
 	req := batchRequest{Batch: &Batch{Shipments: in}}
 	err = c.post(ctx, "batches/create_and_buy", req, &out)
 	return
-}
-
-// ListBatchesResult holds the results from the list insurances API.
-type ListBatchesResult struct {
-	Batch []*Batch `json:"batches,omitempty"`
-	// HasMore indicates if there are more responses to be fetched. If True,
-	// additional responses can be fetched by updating the ListInsurancesOptions
-	// parameter's AfterID field with the ID of the last item in this object's
-	// Insurances field.
-	HasMore bool `json:"has_more,omitempty"`
 }
 
 // ListBatches provides a paginated result of Insurance objects.

--- a/carrier.go
+++ b/carrier.go
@@ -46,6 +46,10 @@ type CarrierType struct {
 	Fields *CarrierFields `json:"fields,omitempty"`
 }
 
+type carrierAccountRequest struct {
+	CarrierAccount *CarrierAccount `json:"carrier_account,omitempty"`
+}
+
 // GetCarrierTypes returns a list of supported carrier types for the current
 // user.
 func (c *Client) GetCarrierTypes() (out []*CarrierType, err error) {
@@ -58,10 +62,6 @@ func (c *Client) GetCarrierTypes() (out []*CarrierType, err error) {
 func (c *Client) GetCarrierTypesWithContext(ctx context.Context) (out []*CarrierType, err error) {
 	err = c.get(ctx, "carrier_types", &out)
 	return
-}
-
-type carrierAccountRequest struct {
-	CarrierAccount *CarrierAccount `json:"carrier_account,omitempty"`
 }
 
 // CreateCarrierAccount creates a new carrier account. It can only be used with

--- a/customs.go
+++ b/customs.go
@@ -43,6 +43,10 @@ type createCustomsInfoRequest struct {
 	CustomsInfo *CustomsInfo `json:"customs_info,omitempty"`
 }
 
+type createCustomsItemRequest struct {
+	CustomsItem *CustomsItem `json:"customs_item,omitempty"`
+}
+
 // CreateCustomsInfo creates a new CustomsInfo object.
 //	c := easypost.New(MyEasyPostAPIKey)
 //	out, err := c.CreateCustomsInfo(
@@ -91,10 +95,6 @@ func (c *Client) GetCustomsInfo(customsInfoID string) (out *CustomsInfo, err err
 func (c *Client) GetCustomsInfoWithContext(ctx context.Context, customsInfoID string) (out *CustomsInfo, err error) {
 	err = c.get(ctx, "customs_infos/"+customsInfoID, &out)
 	return
-}
-
-type createCustomsItemRequest struct {
-	CustomsItem *CustomsItem `json:"customs_item,omitempty"`
 }
 
 // CreateCustomsItem creates a new CustomsItem object.

--- a/error.go
+++ b/error.go
@@ -30,6 +30,10 @@ type APIError struct {
 	Errors []*APIError `json:"errors,omitempty"`
 }
 
+type apiErrorResponse struct {
+	Error *APIError `json:"error,omitempty"`
+}
+
 func (e *APIError) Error() string {
 	if e.Message != "" {
 		if e.Code != "" {
@@ -41,8 +45,4 @@ func (e *APIError) Error() string {
 		return e.Code
 	}
 	return fmt.Sprintf("%d %s", e.StatusCode, e.Status)
-}
-
-type apiErrorResponse struct {
-	Error *APIError `json:"error,omitempty"`
 }

--- a/insurance.go
+++ b/insurance.go
@@ -34,6 +34,16 @@ type createInsuranceRequest struct {
 	Insurance *Insurance `json:"insurance,omitempty"`
 }
 
+// ListInsurancesResult holds the results from the list insurances API.
+type ListInsurancesResult struct {
+	Insurances []*Insurance `json:"insurances,omitempty"`
+	// HasMore indicates if there are more responses to be fetched. If True,
+	// additional responses can be fetched by updating the ListInsurancesOptions
+	// parameter's AfterID field with the ID of the last item in this object's
+	// Insurances field.
+	HasMore bool `json:"has_more,omitempty"`
+}
+
 // CreateInsurance creats an insurance object for a shipment purchased outside
 // of EasyPost. ToAddress, FromAddress, TrackingCode and Amount fields must be
 // provided. Providing a value in the Carrier field is optional, but can help
@@ -60,16 +70,6 @@ func (c *Client) CreateInsuranceWithContext(ctx context.Context, in *Insurance) 
 	req := &createInsuranceRequest{Insurance: in}
 	err = c.post(ctx, "insurances", req, &out)
 	return
-}
-
-// ListInsurancesResult holds the results from the list insurances API.
-type ListInsurancesResult struct {
-	Insurances []*Insurance `json:"insurances,omitempty"`
-	// HasMore indicates if there are more responses to be fetched. If True,
-	// additional responses can be fetched by updating the ListInsurancesOptions
-	// parameter's AfterID field with the ID of the last item in this object's
-	// Insurances field.
-	HasMore bool `json:"has_more,omitempty"`
 }
 
 // ListInsurances provides a paginated result of Insurance objects.

--- a/report.go
+++ b/report.go
@@ -25,26 +25,6 @@ type Report struct {
 	AdditionalColumns []string   `json:"additional_columns,omitempty"`
 }
 
-// CreateReport generates a new report. Valid Fields for input are StartDate,
-// EndDate and SendEmail. A new Report object is returned. Once the Status is
-// available, the report can be downloaded from the provided URL for 30 seconds.
-//	c := easypost.New(MyEasyPostAPIKey)
-//	c.CreateReport(
-//		"payment_log",
-//		&easypost.Report{StartDate: "2016-10-01", EndDate: "2016-10-31"},
-//	)
-func (c *Client) CreateReport(typ string, in *Report) (out *Report, err error) {
-	err = c.post(context.Background(), "reports/"+typ, in, &out)
-	return
-}
-
-// CreateReportWithContext performs the same operation as CreateReport, but
-// allows specifying a context that can interrupt the request.
-func (c *Client) CreateReportWithContext(ctx context.Context, typ string, in *Report) (out *Report, err error) {
-	err = c.post(ctx, "reports/"+typ, in, &out)
-	return
-}
-
 // ListReportsOptions is used to specify query parameters for listing Report
 // objects.
 type ListReportsOptions struct {
@@ -63,6 +43,26 @@ type ListReportsResult struct {
 	// parameter's AfterID field with the ID of the last item in this object's
 	// Reports field.
 	HasMore bool `json:"has_more,omitempty"`
+}
+
+// CreateReport generates a new report. Valid Fields for input are StartDate,
+// EndDate and SendEmail. A new Report object is returned. Once the Status is
+// available, the report can be downloaded from the provided URL for 30 seconds.
+//	c := easypost.New(MyEasyPostAPIKey)
+//	c.CreateReport(
+//		"payment_log",
+//		&easypost.Report{StartDate: "2016-10-01", EndDate: "2016-10-31"},
+//	)
+func (c *Client) CreateReport(typ string, in *Report) (out *Report, err error) {
+	err = c.post(context.Background(), "reports/"+typ, in, &out)
+	return
+}
+
+// CreateReportWithContext performs the same operation as CreateReport, but
+// allows specifying a context that can interrupt the request.
+func (c *Client) CreateReportWithContext(ctx context.Context, typ string, in *Report) (out *Report, err error) {
+	err = c.post(ctx, "reports/"+typ, in, &out)
+	return
 }
 
 // ListReports provides a paginated result of Report objects of the given type.

--- a/scan_form.go
+++ b/scan_form.go
@@ -26,6 +26,16 @@ type scanFormRequest struct {
 	Shipments []*Shipment `json:"shipments,omitempty"`
 }
 
+// ListScanFormsResult holds the results from the list scan forms API.
+type ListScanFormsResult struct {
+	ScanForms []*ScanForm `json:"scan_forms,omitempty"`
+	// HasMore indicates if there are more responses to be fetched. If True,
+	// additional responses can be fetched by updating the ListScanFormsOptions
+	// parameter's AfterID field with the ID of the last item in this object's
+	// ScanForms field.
+	HasMore bool `json:"has_more,omitempty"`
+}
+
 func newscanFormRequest(shipmentIDs ...string) *scanFormRequest {
 	l := len(shipmentIDs)
 	if l == 0 {
@@ -51,16 +61,6 @@ func (c *Client) CreateScanForm(shipmentIDs ...string) (out *ScanForm, err error
 func (c *Client) CreateScanFormWithContext(ctx context.Context, shipmentIDs ...string) (out *ScanForm, err error) {
 	err = c.post(ctx, "scan_forms", newscanFormRequest(shipmentIDs...), &out)
 	return
-}
-
-// ListScanFormsResult holds the results from the list scan forms API.
-type ListScanFormsResult struct {
-	ScanForms []*ScanForm `json:"scan_forms,omitempty"`
-	// HasMore indicates if there are more responses to be fetched. If True,
-	// additional responses can be fetched by updating the ListScanFormsOptions
-	// parameter's AfterID field with the ID of the last item in this object's
-	// ScanForms field.
-	HasMore bool `json:"has_more,omitempty"`
 }
 
 // ListScanForms provides a paginated result of ScanForm objects.

--- a/shipment.go
+++ b/shipment.go
@@ -141,6 +141,37 @@ type Shipment struct {
 	TaxIdentifiers    []*TaxIdentifier  `json:"tax_identifiers,omitempty"`
 }
 
+// ListShipmentsOptions is used to specify query parameters for listing Shipment
+// objects.
+type ListShipmentsOptions struct {
+	BeforeID        string     `url:"before_id,omitempty"`
+	AfterID         string     `url:"after_id,omitempty"`
+	StartDateTime   *time.Time `url:"start_datetime,omitempty"`
+	EndDateTime     *time.Time `url:"end_datetime,omitempty"`
+	PageSize        int        `url:"page_size,omitempty"`
+	Purchased       *bool      `url:"purchased,omitempty"`
+	IncludeChildren *bool      `url:"include_children,omitempty"`
+}
+
+// ListShipmentsResult holds the results from the list shipments API.
+type ListShipmentsResult struct {
+	Shipments []*Shipment `json:"shipments,omitempty"`
+	// HasMore indicates if there are more responses to be fetched. If True,
+	// additional responses can be fetched by updating the ListShipmentsOptions
+	// parameter's AfterID field with the ID of the last item in this object's
+	// Shipments field.
+	HasMore bool `json:"has_more,omitempty"`
+}
+
+type buyShipmentRequest struct {
+	Rate      *Rate  `json:"rate,omitempty"`
+	Insurance string `json:"insurance,omitempty"`
+}
+
+type getShipmentRatesResponse struct {
+	Rates *[]*Rate `json:"rates,omitempty"`
+}
+
 // CreateShipment creates a new Shipment object. The ToAddress, FromAddress and
 // Parcel attributes are required. These objects may be fully-specified to
 // create new ones at the same time as creating the Shipment, or they can refer
@@ -188,28 +219,6 @@ func (c *Client) CreateShipmentWithContext(ctx context.Context, in *Shipment) (o
 	return
 }
 
-// ListShipmentsOptions is used to specify query parameters for listing Shipment
-// objects.
-type ListShipmentsOptions struct {
-	BeforeID        string     `url:"before_id,omitempty"`
-	AfterID         string     `url:"after_id,omitempty"`
-	StartDateTime   *time.Time `url:"start_datetime,omitempty"`
-	EndDateTime     *time.Time `url:"end_datetime,omitempty"`
-	PageSize        int        `url:"page_size,omitempty"`
-	Purchased       *bool      `url:"purchased,omitempty"`
-	IncludeChildren *bool      `url:"include_children,omitempty"`
-}
-
-// ListShipmentsResult holds the results from the list shipments API.
-type ListShipmentsResult struct {
-	Shipments []*Shipment `json:"shipments,omitempty"`
-	// HasMore indicates if there are more responses to be fetched. If True,
-	// additional responses can be fetched by updating the ListShipmentsOptions
-	// parameter's AfterID field with the ID of the last item in this object's
-	// Shipments field.
-	HasMore bool `json:"has_more,omitempty"`
-}
-
 // ListShipments provides a paginated result of Shipment objects.
 func (c *Client) ListShipments(opts *ListShipmentsOptions) (out *ListShipmentsResult, err error) {
 	return c.ListShipmentsWithContext(context.Background(), opts)
@@ -233,11 +242,6 @@ func (c *Client) GetShipment(shipmentID string) (out *Shipment, err error) {
 func (c *Client) GetShipmentWithContext(ctx context.Context, shipmentID string) (out *Shipment, err error) {
 	err = c.get(ctx, "shipments/"+shipmentID, &out)
 	return
-}
-
-type buyShipmentRequest struct {
-	Rate      *Rate  `json:"rate,omitempty"`
-	Insurance string `json:"insurance,omitempty"`
 }
 
 // BuyShipment purchases a shipment. If successful, the returned Shipment will
@@ -273,10 +277,6 @@ func (c *Client) GetShipmentLabelWithContext(ctx context.Context, shipmentID, fo
 	vals := url.Values{"file_format": []string{format}}
 	err = c.do(ctx, http.MethodGet, "shipments/"+shipmentID+"/label", vals, &out)
 	return
-}
-
-type getShipmentRatesResponse struct {
-	Rates *[]*Rate `json:"rates,omitempty"`
 }
 
 // GetShipmentSmartrates fetches the available smartrates for a shipment.

--- a/tracker.go
+++ b/tracker.go
@@ -77,6 +77,39 @@ type CreateTrackerOptions struct {
 	FullTestTracker bool
 }
 
+// ListTrackersOptions is used to specify query parameters for listing Tracker
+// objects.
+type ListTrackersOptions struct {
+	BeforeID      string     `url:"before_id,omitempty"`
+	AfterID       string     `url:"after_id,omitempty"`
+	StartDateTime *time.Time `url:"start_datetime,omitempty"`
+	EndDateTime   *time.Time `url:"end_datetime,omitempty"`
+	PageSize      int        `url:"page_size,omitempty"`
+	TrackingCodes []string   `url:"tracking_codes,omitempty"`
+	Carrier       string     `url:"carrier,omitempty"`
+}
+
+// ListTrackersResult holds the results from the list trackers API.
+type ListTrackersResult struct {
+	Trackers []*Tracker `json:"trackers,omitempty"`
+	// HasMore indicates if there are more responses to be fetched. If True,
+	// additional responses can be fetched by updating the ListTrackersOptions
+	// parameter's AfterID field with the ID of the last item in this object's
+	// Trackers field.
+	HasMore bool `json:"has_more,omitempty"`
+}
+
+// ListTrackersUpdatedOptions specifies options for the list trackers updated
+// API.
+type ListTrackersUpdatedOptions struct {
+	Page                 int        `json:"page,omitempty"`
+	PageSize             int        `json:"page_size,omitempty"`
+	StatusStart          *time.Time `json:"status_start,omitempty"`
+	StatusEnd            *time.Time `json:"status_end,omitempty"`
+	TrackingDetailsStart *time.Time `json:"tracking_details_start,omitempty"`
+	TrackingDetailsEnd   *time.Time `json:"tracking_details_end,omitempty"`
+}
+
 func (c *CreateTrackerOptions) toMap() map[string]interface{} {
 	trackerParams := make(map[string]interface{})
 	if c.TrackingCode != "" {
@@ -152,28 +185,6 @@ func (c *Client) CreateTrackerListWithContext(ctx context.Context, param map[str
 	return true, c.post(ctx, "trackers/create_list", req, nil)
 }
 
-// ListTrackersOptions is used to specify query parameters for listing Tracker
-// objects.
-type ListTrackersOptions struct {
-	BeforeID      string     `url:"before_id,omitempty"`
-	AfterID       string     `url:"after_id,omitempty"`
-	StartDateTime *time.Time `url:"start_datetime,omitempty"`
-	EndDateTime   *time.Time `url:"end_datetime,omitempty"`
-	PageSize      int        `url:"page_size,omitempty"`
-	TrackingCodes []string   `url:"tracking_codes,omitempty"`
-	Carrier       string     `url:"carrier,omitempty"`
-}
-
-// ListTrackersResult holds the results from the list trackers API.
-type ListTrackersResult struct {
-	Trackers []*Tracker `json:"trackers,omitempty"`
-	// HasMore indicates if there are more responses to be fetched. If True,
-	// additional responses can be fetched by updating the ListTrackersOptions
-	// parameter's AfterID field with the ID of the last item in this object's
-	// Trackers field.
-	HasMore bool `json:"has_more,omitempty"`
-}
-
 // ListTrackers provides a paginated result of Tracker objects.
 func (c *Client) ListTrackers(opts *ListTrackersOptions) (out *ListTrackersResult, err error) {
 	return c.ListTrackersWithContext(context.Background(), opts)
@@ -184,17 +195,6 @@ func (c *Client) ListTrackers(opts *ListTrackersOptions) (out *ListTrackersResul
 func (c *Client) ListTrackersWithContext(ctx context.Context, opts *ListTrackersOptions) (out *ListTrackersResult, err error) {
 	err = c.do(ctx, http.MethodGet, "trackers", c.convertOptsToURLValues(opts), &out)
 	return
-}
-
-// ListTrackersUpdatedOptions specifies options for the list trackers updated
-// API.
-type ListTrackersUpdatedOptions struct {
-	Page                 int        `json:"page,omitempty"`
-	PageSize             int        `json:"page_size,omitempty"`
-	StatusStart          *time.Time `json:"status_start,omitempty"`
-	StatusEnd            *time.Time `json:"status_end,omitempty"`
-	TrackingDetailsStart *time.Time `json:"tracking_details_start,omitempty"`
-	TrackingDetailsEnd   *time.Time `json:"tracking_details_end,omitempty"`
 }
 
 // GetTracker retrieves a Tracker object by ID.

--- a/webhook.go
+++ b/webhook.go
@@ -18,6 +18,10 @@ type createWebhookRequest struct {
 	Webhook *Webhook `json:"webhook,omitempty"`
 }
 
+type listWebhooksResult struct {
+	Webhooks *[]*Webhook `json:"webhooks,omitempty"`
+}
+
 // CreateWebhook creates a new webhook with the given URL.
 func (c *Client) CreateWebhook(u string) (out *Webhook, err error) {
 	req := &createWebhookRequest{Webhook: &Webhook{URL: u}}
@@ -31,10 +35,6 @@ func (c *Client) CreateWebhookWithContext(ctx context.Context, u string) (out *W
 	req := &createWebhookRequest{Webhook: &Webhook{URL: u}}
 	err = c.post(ctx, "webhooks", req, &out)
 	return
-}
-
-type listWebhooksResult struct {
-	Webhooks *[]*Webhook `json:"webhooks,omitempty"`
 }
 
 // ListWebhooks returns all webhooks associated with the EasyPost account.


### PR DESCRIPTION
# Description

Moves structs to the top of the file so they are all next to each other. Ensures structs appear first followed by functions for easier maintenance and grouping.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

NA

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
