### PR TITLE
fix: use require.NoError in tests

### DIFF
--- a/tests/address_test.go
+++ b/tests/address_test.go
@@ -9,16 +9,13 @@ import (
 
 func (c *ClientTests) TestAddressCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	address, err := client.CreateAddress(
 		c.fixture.BasicAddress(),
 		nil,
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
 	assert.True(strings.HasPrefix(address.ID, "adr_"))
@@ -27,7 +24,7 @@ func (c *ClientTests) TestAddressCreate() {
 
 func (c *ClientTests) TestAddressCreateVerifyStrict() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	address, err := client.CreateAddress(
 		c.fixture.BasicAddress(),
@@ -35,10 +32,7 @@ func (c *ClientTests) TestAddressCreateVerifyStrict() {
 			VerifyStrict: []string{"true"},
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
 	assert.True(strings.HasPrefix(address.ID, "adr_"))
@@ -47,22 +41,16 @@ func (c *ClientTests) TestAddressCreateVerifyStrict() {
 
 func (c *ClientTests) TestAddressRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	address, err := client.CreateAddress(
 		c.fixture.BasicAddress(),
 		nil,
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedAddress, err := client.GetAddress(address.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(retrievedAddress))
 	assert.Equal(address, retrievedAddress)
@@ -70,17 +58,14 @@ func (c *ClientTests) TestAddressRetrieve() {
 
 func (c *ClientTests) TestAddressAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	addresses, err := client.ListAddresses(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.LessOrEqual(len(addresses.Addresses), c.fixture.pageSize())
 	assert.NotNil(addresses.HasMore)
@@ -92,7 +77,7 @@ func (c *ClientTests) TestAddressAll() {
 // We purposefully pass in slightly incorrect data to get the corrected address back once verified.
 func (c *ClientTests) TestAddressCreateVerify() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	address, err := client.CreateAddress(
 		c.fixture.IncorrectAddressToVerify(),
@@ -100,10 +85,7 @@ func (c *ClientTests) TestAddressCreateVerify() {
 			Verify: []string{"delivery"},
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
 	assert.True(strings.HasPrefix(address.ID, "adr_"))
@@ -112,7 +94,7 @@ func (c *ClientTests) TestAddressCreateVerify() {
 
 func (c *ClientTests) TestAddressCreateAndVerify() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	address, err := client.CreateAndVerifyAddress(
 		c.fixture.IncorrectAddressToVerify(),
@@ -120,10 +102,7 @@ func (c *ClientTests) TestAddressCreateAndVerify() {
 			Verify: []string{"delivery"},
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
 	assert.True(strings.HasPrefix(address.ID, "adr_"))
@@ -132,22 +111,16 @@ func (c *ClientTests) TestAddressCreateAndVerify() {
 
 func (c *ClientTests) TestAddressVerify() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	address, err := client.CreateAddress(
 		c.fixture.BasicAddress(),
 		nil,
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	verifiedAddress, err := client.VerifyAddress(address.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(verifiedAddress))
 	assert.True(strings.HasPrefix(verifiedAddress.ID, "adr_"))

--- a/tests/batch_test.go
+++ b/tests/batch_test.go
@@ -13,16 +13,13 @@ import (
 
 func (c *ClientTests) TestBatchCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	batch, err := client.CreateBatch(
 		c.fixture.BasicShipment(),
 		nil,
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Batch{}), reflect.TypeOf(batch))
 	assert.True(strings.HasPrefix(batch.ID, "batch_"))
@@ -31,22 +28,16 @@ func (c *ClientTests) TestBatchCreate() {
 
 func (c *ClientTests) TestBatchRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	batch, err := client.CreateBatch(
 		c.fixture.BasicShipment(),
 		nil,
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedBatch, err := client.GetBatch(batch.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Batch{}), reflect.TypeOf(retrievedBatch))
 	assert.Equal(batch.ID, retrievedBatch.ID)
@@ -54,17 +45,14 @@ func (c *ClientTests) TestBatchRetrieve() {
 
 func (c *ClientTests) TestBatchAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	batches, err := client.ListBatches(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.LessOrEqual(len(batches.Batch), c.fixture.pageSize())
 	assert.NotNil(batches.HasMore)
@@ -75,13 +63,10 @@ func (c *ClientTests) TestBatchAll() {
 
 func (c *ClientTests) TestBatchCreateAndBuy() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	batch, err := client.CreateAndBuyBatch(c.fixture.OneCallBuyShipment(), c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Batch{}), reflect.TypeOf(batch))
 	assert.True(strings.HasPrefix(batch.ID, "batch_"))
@@ -90,22 +75,16 @@ func (c *ClientTests) TestBatchCreateAndBuy() {
 
 func (c *ClientTests) TestBatchBuy() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	batch, err := client.CreateBatch(
 		c.fixture.OneCallBuyShipment(),
 		nil,
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	boughtBatch, err := client.BuyBatch(batch.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Batch{}), reflect.TypeOf(boughtBatch))
 	assert.Equal(1, boughtBatch.NumShipments)
@@ -113,22 +92,16 @@ func (c *ClientTests) TestBatchBuy() {
 
 func (c *ClientTests) TestBatchCreateScanForm() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	batch, err := client.CreateBatch(
 		c.fixture.OneCallBuyShipment(),
 		nil,
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	boughtBatch, err := client.BuyBatch(batch.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	currentDir, _ := os.Getwd()
 	cassettePath := filepath.Join(currentDir, "cassettes", "TestBatchCreateScanForm.yaml")
@@ -137,10 +110,7 @@ func (c *ClientTests) TestBatchCreateScanForm() {
 	}
 
 	batchWithScanForm, err := client.CreateBatchScanForms(boughtBatch.ID, "")
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	// We can't assert anything meaningful here because the scanform gets queued for generation and may not be immediately available
 	assert.Equal(reflect.TypeOf(&easypost.Batch{}), reflect.TypeOf(batchWithScanForm))
@@ -148,60 +118,39 @@ func (c *ClientTests) TestBatchCreateScanForm() {
 
 func (c *ClientTests) TestBatchAddRemoveShipment() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 	shipment2, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	batch, err := client.CreateBatch()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	batchWithShipment, err := client.AddShipmentsToBatch(batch.ID, shipment.ID, shipment2.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(2, batchWithShipment.NumShipments)
 
 	batchWithoutShipment, err := client.RemoveShipmentsFromBatch(batch.ID, shipment.ID, shipment2.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(0, batchWithoutShipment.NumShipments)
 }
 
 func (c *ClientTests) TestBatchLabel() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	batch, err := client.CreateBatch(
 		c.fixture.OneCallBuyShipment(),
 		nil,
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	boughtBatch, err := client.BuyBatch(batch.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	currentDir, _ := os.Getwd()
 	cassettePath := filepath.Join(currentDir, "cassettes", "TestBatchLabel.yaml")
@@ -210,10 +159,7 @@ func (c *ClientTests) TestBatchLabel() {
 	}
 
 	batchWithLabel, err := client.GetBatchLabels(boughtBatch.ID, "ZPL")
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	// We can't assert anything meaningful here because the label gets queued for generation and may not be immediately available
 	assert.Equal(reflect.TypeOf(&easypost.Batch{}), reflect.TypeOf(batchWithLabel))

--- a/tests/carrier_account_test.go
+++ b/tests/carrier_account_test.go
@@ -20,10 +20,7 @@ func (c *ClientTests) TestCarrierAccountCreate() {
 	assert, require := c.Assert(), c.Require()
 
 	carrierAccount, err := c.GenerateCarrierAccount()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.CarrierAccount{}), reflect.TypeOf(carrierAccount))
 	assert.True(strings.HasPrefix(carrierAccount.ID, "ca_"))
@@ -39,16 +36,10 @@ func (c *ClientTests) TestCarrierAccountRetrieve() {
 	assert, require := c.Assert(), c.Require()
 
 	carrierAccount, err := c.GenerateCarrierAccount()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedCarrierAccount, err := client.GetCarrierAccount(carrierAccount.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.CarrierAccount{}), reflect.TypeOf(retrievedCarrierAccount))
 	assert.Equal(carrierAccount, retrievedCarrierAccount)
@@ -60,13 +51,10 @@ func (c *ClientTests) TestCarrierAccountRetrieve() {
 
 func (c *ClientTests) TestCarrierAccountAll() {
 	client := c.ProdClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	carrierAccounts, err := client.ListCarrierAccounts()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	for _, carrierAccount := range carrierAccounts {
 		assert.Equal(reflect.TypeOf(&easypost.CarrierAccount{}), reflect.TypeOf(carrierAccount))
@@ -80,18 +68,12 @@ func (c *ClientTests) TestCarrierAccountUpdate() {
 	testDescription := "My custom description"
 
 	carrierAccount, err := c.GenerateCarrierAccount()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	carrierAccount.Description = testDescription
 
 	updatedCarrierAccount, err := client.UpdateCarrierAccount(carrierAccount)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.CarrierAccount{}), reflect.TypeOf(updatedCarrierAccount))
 	assert.True(strings.HasPrefix(updatedCarrierAccount.ID, "ca_"))
@@ -107,10 +89,7 @@ func (c *ClientTests) TestCarrierAccountDelete() {
 	require := c.Require()
 
 	carrierAccount, err := c.GenerateCarrierAccount()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	err = client.DeleteCarrierAccount(carrierAccount.ID)
 
@@ -119,13 +98,10 @@ func (c *ClientTests) TestCarrierAccountDelete() {
 
 func (c *ClientTests) TestCarrierAccountTypes() {
 	client := c.ProdClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	carriersAccountTypes, err := client.GetCarrierTypes()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf([]*easypost.CarrierType{}), reflect.TypeOf(carriersAccountTypes))
 }

--- a/tests/customs_info_test.go
+++ b/tests/customs_info_test.go
@@ -9,13 +9,10 @@ import (
 
 func (c *ClientTests) TestCustomsInfoCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	customsInfo, err := client.CreateCustomsInfo(c.fixture.BasicCustomsInfo())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.CustomsInfo{}), reflect.TypeOf(customsInfo))
 	assert.True(strings.HasPrefix(customsInfo.ID, "cstinfo_"))
@@ -24,19 +21,13 @@ func (c *ClientTests) TestCustomsInfoCreate() {
 
 func (c *ClientTests) TestCustomsInfoRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	customsInfo, err := client.CreateCustomsInfo(c.fixture.BasicCustomsInfo())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedCustomsInfo, err := client.GetCustomsInfo(customsInfo.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.CustomsInfo{}), reflect.TypeOf(retrievedCustomsInfo))
 	assert.Equal(customsInfo, retrievedCustomsInfo)

--- a/tests/customs_item_test.go
+++ b/tests/customs_item_test.go
@@ -9,13 +9,10 @@ import (
 
 func (c *ClientTests) TestCustomsItemCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	customsItem, err := client.CreateCustomsItem(c.fixture.BasicCustomsItem())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.CustomsItem{}), reflect.TypeOf(customsItem))
 	assert.True(strings.HasPrefix(customsItem.ID, "cstitem_"))
@@ -24,19 +21,13 @@ func (c *ClientTests) TestCustomsItemCreate() {
 
 func (c *ClientTests) TestCustomsItemRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	customsItem, err := client.CreateCustomsItem(c.fixture.BasicCustomsItem())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedCustomsItem, err := client.GetCustomsItem(customsItem.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.CustomsItem{}), reflect.TypeOf(retrievedCustomsItem))
 	assert.Equal(customsItem, retrievedCustomsItem)

--- a/tests/event_test.go
+++ b/tests/event_test.go
@@ -9,17 +9,14 @@ import (
 
 func (c *ClientTests) TestEventAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	events, err := client.ListEvents(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	eventsList := events.Events
 
@@ -32,23 +29,17 @@ func (c *ClientTests) TestEventAll() {
 
 func (c *ClientTests) TestEventRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	events, err := client.ListEvents(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	event, err := client.GetEvent(events.Events[0].ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Event{}), reflect.TypeOf(event))
 	assert.True(strings.HasPrefix(event.ID, "evt_"))

--- a/tests/insurance_test.go
+++ b/tests/insurance_test.go
@@ -9,22 +9,16 @@ import (
 
 func (c *ClientTests) TestInsuranceCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	insuranceData := c.fixture.BasicInsurance()
 	insuranceData.TrackingCode = shipment.TrackingCode
 
 	insurance, err := client.CreateInsurance(insuranceData)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Insurance{}), reflect.TypeOf(insurance))
 	assert.True(strings.HasPrefix(insurance.ID, "ins_"))
@@ -33,28 +27,19 @@ func (c *ClientTests) TestInsuranceCreate() {
 
 func (c *ClientTests) TestInsuranceRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	insuranceData := c.fixture.BasicInsurance()
 	insuranceData.TrackingCode = shipment.TrackingCode
 
 	insurance, err := client.CreateInsurance(insuranceData)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedInsurance, err := client.GetInsurance(insurance.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Insurance{}), reflect.TypeOf(retrievedInsurance))
 	assert.Equal(insurance, retrievedInsurance)
@@ -62,17 +47,14 @@ func (c *ClientTests) TestInsuranceRetrieve() {
 
 func (c *ClientTests) TestInsuranceAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	insurances, err := client.ListInsurances(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	insurancesList := insurances.Insurances
 

--- a/tests/order_test.go
+++ b/tests/order_test.go
@@ -9,13 +9,10 @@ import (
 
 func (c *ClientTests) TestOrderCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	order, err := client.CreateOrder(c.fixture.BasicOrder())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Order{}), reflect.TypeOf(order))
 	assert.True(strings.HasPrefix(order.ID, "order_"))
@@ -24,19 +21,13 @@ func (c *ClientTests) TestOrderCreate() {
 
 func (c *ClientTests) TestOrderRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	order, err := client.CreateOrder(c.fixture.BasicOrder())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedOrder, err := client.GetOrder(order.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Order{}), reflect.TypeOf(retrievedOrder))
 	assert.Equal(order.ID, retrievedOrder.ID)
@@ -44,19 +35,13 @@ func (c *ClientTests) TestOrderRetrieve() {
 
 func (c *ClientTests) TestOrderGetRates() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	order, err := client.CreateOrder(c.fixture.BasicOrder())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	rates, err := client.GetOrderRates(order.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	ratesList := rates.Rates
 
@@ -68,19 +53,13 @@ func (c *ClientTests) TestOrderGetRates() {
 
 func (c *ClientTests) TestOrderBuyRate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	order, err := client.CreateOrder(c.fixture.BasicOrder())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	boughtOrder, err := client.BuyOrder(order.ID, c.fixture.USPS(), c.fixture.USPSService())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	shipmentsList := boughtOrder.Shipments
 

--- a/tests/parcel_test.go
+++ b/tests/parcel_test.go
@@ -9,13 +9,10 @@ import (
 
 func (c *ClientTests) TestParcelCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	parcel, err := client.CreateParcel(c.fixture.BasicParcel())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Parcel{}), reflect.TypeOf(parcel))
 	assert.True(strings.HasPrefix(parcel.ID, "prcl_"))
@@ -24,19 +21,13 @@ func (c *ClientTests) TestParcelCreate() {
 
 func (c *ClientTests) TestParcelRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	parcel, err := client.CreateParcel(c.fixture.BasicParcel())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedParcel, err := client.GetParcel(parcel.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Parcel{}), reflect.TypeOf(retrievedParcel))
 	assert.Equal(parcel, retrievedParcel)

--- a/tests/pickup_test.go
+++ b/tests/pickup_test.go
@@ -9,22 +9,16 @@ import (
 
 func (c *ClientTests) TestPickupCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	pickupData := c.fixture.BasicPickup()
 	pickupData.Shipment = shipment
 
 	pickup, err := client.CreatePickup(pickupData)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Pickup{}), reflect.TypeOf(pickup))
 	assert.True(strings.HasPrefix(pickup.ID, "pickup_"))
@@ -33,28 +27,19 @@ func (c *ClientTests) TestPickupCreate() {
 
 func (c *ClientTests) TestPickupRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	pickupData := c.fixture.BasicPickup()
 	pickupData.Shipment = shipment
 
 	pickup, err := client.CreatePickup(pickupData)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievePickup, err := client.GetPickup(pickup.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Pickup{}), reflect.TypeOf(retrievePickup))
 	assert.Equal(pickup, retrievePickup)
@@ -62,22 +47,16 @@ func (c *ClientTests) TestPickupRetrieve() {
 
 func (c *ClientTests) TestPickupBuy() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	pickupData := c.fixture.BasicPickup()
 	pickupData.Shipment = shipment
 
 	pickup, err := client.CreatePickup(pickupData)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	boughtPickup, err := client.BuyPickup(
 		pickup.ID,
@@ -86,10 +65,7 @@ func (c *ClientTests) TestPickupBuy() {
 			Service: c.fixture.PickupService(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Pickup{}), reflect.TypeOf(boughtPickup))
 	assert.True(strings.HasPrefix(boughtPickup.ID, "pickup_"))
@@ -99,22 +75,16 @@ func (c *ClientTests) TestPickupBuy() {
 
 func (c *ClientTests) TestPickupCancel() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	pickupData := c.fixture.BasicPickup()
 	pickupData.Shipment = shipment
 
 	pickup, err := client.CreatePickup(pickupData)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	boughtPickup, err := client.BuyPickup(
 		pickup.ID,
@@ -123,16 +93,10 @@ func (c *ClientTests) TestPickupCancel() {
 			Service: c.fixture.PickupService(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	cancelledPickup, err := client.CancelPickup(boughtPickup.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Pickup{}), reflect.TypeOf(cancelledPickup))
 	assert.True(strings.HasPrefix(cancelledPickup.ID, "pickup_"))

--- a/tests/rate_test.go
+++ b/tests/rate_test.go
@@ -9,19 +9,13 @@ import (
 
 func (c *ClientTests) TestRateRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.BasicShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	rate, err := client.GetRate(shipment.Rates[0].ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Rate{}), reflect.TypeOf(rate))
 	assert.True(strings.HasPrefix(rate.ID, "rate_"))

--- a/tests/refund_test.go
+++ b/tests/refund_test.go
@@ -9,19 +9,13 @@ import (
 
 func (c *ClientTests) TestRefundCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedShipment, err := client.GetShipment(shipment.ID) // We need to retrieve the shipment so that the tracking_code has time to populate
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	refund, err := client.CreateRefund(
 		map[string]interface{}{
@@ -29,10 +23,7 @@ func (c *ClientTests) TestRefundCreate() {
 			"tracking_codes": retrievedShipment.TrackingCode,
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.True(strings.HasPrefix(refund[0].ID, "rfnd_"))
 	assert.Equal("submitted", refund[0].Status)
@@ -40,17 +31,14 @@ func (c *ClientTests) TestRefundCreate() {
 
 func (c *ClientTests) TestRefundAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	refunds, err := client.ListRefunds(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	refundsList := refunds.Refunds
 
@@ -63,23 +51,17 @@ func (c *ClientTests) TestRefundAll() {
 
 func (c *ClientTests) TestRefundRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	refunds, err := client.ListRefunds(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedRefund, err := client.GetRefund(refunds.Refunds[0].ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Refund{}), reflect.TypeOf(retrievedRefund))
 	assert.Equal(refunds.Refunds[0].ID, retrievedRefund.ID)

--- a/tests/report_test.go
+++ b/tests/report_test.go
@@ -9,7 +9,7 @@ import (
 
 func (c *ClientTests) TestReportCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	report, err := client.CreateReport(
 		c.fixture.ReportType(),
@@ -18,10 +18,7 @@ func (c *ClientTests) TestReportCreate() {
 			EndDate:   c.fixture.ReportDate(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Report{}), reflect.TypeOf(report))
 	assert.True(strings.HasPrefix(report.ID, "shprep_"))
@@ -29,7 +26,7 @@ func (c *ClientTests) TestReportCreate() {
 
 func (c *ClientTests) TestReportCustomColumnsCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	report, err := client.CreateReport(
 		c.fixture.ReportType(),
@@ -39,10 +36,7 @@ func (c *ClientTests) TestReportCustomColumnsCreate() {
 			Columns:   []string{"usps_zone"},
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	// verify parameters by checking VCR cassette for correct URL
 	// Some reports take a long time to generate, so we won't be able to consistently pull the report
@@ -54,7 +48,7 @@ func (c *ClientTests) TestReportCustomColumnsCreate() {
 
 func (c *ClientTests) TestReportCustomAdditionalColumnsCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	report, err := client.CreateReport(
 		c.fixture.ReportType(),
@@ -64,10 +58,7 @@ func (c *ClientTests) TestReportCustomAdditionalColumnsCreate() {
 			AdditionalColumns: []string{"from_name", "from_company"},
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	// verify parameters by checking VCR cassette for correct URL
 	// Some reports take a long time to generate, so we won't be able to consistently pull the report
@@ -79,7 +70,7 @@ func (c *ClientTests) TestReportCustomAdditionalColumnsCreate() {
 
 func (c *ClientTests) TestReportRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	report, err := client.CreateReport(
 		c.fixture.ReportType(),
@@ -88,16 +79,10 @@ func (c *ClientTests) TestReportRetrieve() {
 			EndDate:   c.fixture.ReportDate(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedReport, err := client.GetReport(c.fixture.ReportType(), report.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Report{}), reflect.TypeOf(retrievedReport))
 	assert.Equal(report.StartDate, retrievedReport.StartDate)
@@ -106,7 +91,7 @@ func (c *ClientTests) TestReportRetrieve() {
 
 func (c *ClientTests) TestReportAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	reports, err := client.ListReports(
 		c.fixture.ReportType(),
@@ -114,10 +99,7 @@ func (c *ClientTests) TestReportAll() {
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	reportsList := reports.Reports
 

--- a/tests/scan_form_test.go
+++ b/tests/scan_form_test.go
@@ -9,19 +9,13 @@ import (
 
 func (c *ClientTests) TestScanFormCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	scanform, err := client.CreateScanForm(shipment.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.ScanForm{}), reflect.TypeOf(scanform))
 	assert.True(strings.HasPrefix(scanform.ID, "sf_"))
@@ -29,25 +23,16 @@ func (c *ClientTests) TestScanFormCreate() {
 
 func (c *ClientTests) TestScanFormRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	scanform, err := client.CreateScanForm(shipment.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedScanform, err := client.GetScanForm(scanform.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.ScanForm{}), reflect.TypeOf(retrievedScanform))
 	assert.Equal(scanform, retrievedScanform)
@@ -55,17 +40,14 @@ func (c *ClientTests) TestScanFormRetrieve() {
 
 func (c *ClientTests) TestScanFormAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	scanforms, err := client.ListScanForms(
 		&easypost.ListOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	scanformsList := scanforms.ScanForms
 

--- a/tests/shipment_test.go
+++ b/tests/shipment_test.go
@@ -9,13 +9,10 @@ import (
 
 func (c *ClientTests) TestShipmentCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.FullShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(shipment))
 	assert.True(strings.HasPrefix(shipment.ID, "shp_"))
@@ -27,19 +24,13 @@ func (c *ClientTests) TestShipmentCreate() {
 
 func (c *ClientTests) TestShipmentRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.FullShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedShipment, err := client.GetShipment(shipment.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(retrievedShipment))
 	assert.Equal(shipment, retrievedShipment)
@@ -47,17 +38,14 @@ func (c *ClientTests) TestShipmentRetrieve() {
 
 func (c *ClientTests) TestShipmentAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipments, err := client.ListShipments(
 		&easypost.ListShipmentsOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	shipmentsList := shipments.Shipments
 
@@ -70,44 +58,29 @@ func (c *ClientTests) TestShipmentAll() {
 
 func (c *ClientTests) TestShipmentBuy() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.FullShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	lowestRate, err := client.LowestRate(shipment)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	boughtShipment, err := client.BuyShipment(shipment.ID, &lowestRate, "")
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.NotNil(boughtShipment.PostageLabel)
 }
 
 func (c *ClientTests) TestShipmentRegenerateRates() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.FullShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	rates, err := client.RerateShipment(shipment.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf([]*easypost.Rate{}), reflect.TypeOf(rates))
 	for _, rate := range rates {
@@ -117,19 +90,13 @@ func (c *ClientTests) TestShipmentRegenerateRates() {
 
 func (c *ClientTests) TestShipmentConvertLabel() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	shipmentWithNewLabel, err := client.GetShipmentLabel(shipment.ID, "ZPL")
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.NotNil(shipmentWithNewLabel.PostageLabel.LabelZPLURL)
 }
@@ -138,23 +105,17 @@ func (c *ClientTests) TestShipmentConvertLabel() {
 // so that USPS doesn't automatically insure it so we could manually insure it here.
 func (c *ClientTests) TestShipmentInsure() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipmentData := c.fixture.OneCallBuyShipment()
 	// Set to 0 so USPS doesn't insure this automatically and we can insure the shipment manually
 	shipmentData.Insurance = "0"
 
 	shipment, err := client.CreateShipment(shipmentData)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	insuredShipment, err := client.InsureShipment(shipment.ID, "100")
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal("100.00", insuredShipment.Insurance)
 }
@@ -164,40 +125,28 @@ func (c *ClientTests) TestShipmentInsure() {
 // than a few seconds in test mode may not be refundable.
 func (c *ClientTests) TestShipmentRefund() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.OneCallBuyShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	refundShipment, err := client.RefundShipment(shipment.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal("submitted", refundShipment.RefundStatus)
 }
 
 func (c *ClientTests) TestShipmentSmartrate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipment, err := client.CreateShipment(c.fixture.BasicShipment())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.NotNil(shipment.Rates)
 
 	smartrates, err := client.GetShipmentSmartrates(shipment.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(shipment.Rates[0].ID, smartrates[0].ID)
 	assert.NotNil(smartrates[0].TimeInTransit.Percentile50)
@@ -211,7 +160,7 @@ func (c *ClientTests) TestShipmentSmartrate() {
 
 func (c *ClientTests) TestShipmentCreateEmptyObjects() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipmentData := c.fixture.BasicShipment()
 	shipmentData.Options = nil
@@ -221,10 +170,7 @@ func (c *ClientTests) TestShipmentCreateEmptyObjects() {
 	shipmentData.CustomsInfo.CustomsItems = []*easypost.CustomsItem{}
 
 	shipment, err := client.CreateShipment(shipmentData)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(shipment))
 	assert.True(strings.HasPrefix(shipment.ID, "shp_"))
@@ -236,16 +182,13 @@ func (c *ClientTests) TestShipmentCreateEmptyObjects() {
 
 func (c *ClientTests) TestShipmentCreateTaxIdentifier() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	shipmentData := c.fixture.BasicShipment()
 	shipmentData.TaxIdentifiers = []*easypost.TaxIdentifier{c.fixture.TaxIdentifier()}
 
 	shipment, err := client.CreateShipment(shipmentData)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(shipment))
 	assert.True(strings.HasPrefix(shipment.ID, "shp_"))
@@ -254,23 +197,14 @@ func (c *ClientTests) TestShipmentCreateTaxIdentifier() {
 
 func (c *ClientTests) TestShipmentCreateWithIds() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	fromAddress, err := client.CreateAddress(c.fixture.BasicAddress(), nil)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 	toAddress, err := client.CreateAddress(c.fixture.BasicAddress(), nil)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 	parcel, err := client.CreateParcel(c.fixture.BasicParcel())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	shipment, err := client.CreateShipment(
 		&easypost.Shipment{
@@ -279,10 +213,7 @@ func (c *ClientTests) TestShipmentCreateWithIds() {
 			Parcel:      &easypost.Parcel{ID: parcel.ID},
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Shipment{}), reflect.TypeOf(shipment))
 	assert.True(strings.HasPrefix(shipment.ID, "shp_"))

--- a/tests/tracker_test.go
+++ b/tests/tracker_test.go
@@ -10,17 +10,14 @@ import (
 
 func (c *ClientTests) TestTrackerCreate() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	tracker, err := client.CreateTracker(
 		&easypost.CreateTrackerOptions{
 			TrackingCode: "EZ1000000001",
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Tracker{}), reflect.TypeOf(tracker))
 	assert.True(strings.HasPrefix(tracker.ID, "trk_"))
@@ -29,24 +26,18 @@ func (c *ClientTests) TestTrackerCreate() {
 
 func (c *ClientTests) TestTrackerRetrieve() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	tracker, err := client.CreateTracker(
 		&easypost.CreateTrackerOptions{
 			TrackingCode: "EZ1000000001",
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	// Test trackers cycle through their "dummy" statuses automatically, the created and retrieved objects may differ
 	retrievedTracker, err := client.GetTracker(tracker.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Tracker{}), reflect.TypeOf(retrievedTracker))
 	assert.Equal(tracker.ID, retrievedTracker.ID)
@@ -54,17 +45,14 @@ func (c *ClientTests) TestTrackerRetrieve() {
 
 func (c *ClientTests) TestTrackerAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	trackers, err := client.ListTrackers(
 		&easypost.ListTrackersOptions{
 			PageSize: c.fixture.pageSize(),
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	trackersList := trackers.Trackers
 
@@ -89,12 +77,8 @@ func (c *ClientTests) TestTrackerCreateList() {
 	}
 
 	response, err := client.CreateTrackerList(trackingCodeParam)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	// This endpoint returns nothing so we assert the function returns true
 	assert.True(response)
-	require.NoError(err)
 }

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -11,7 +11,7 @@ func (c *ClientTests) TestUserCreate() {
 	c.T().Skip("This endpoint returns the child user keys in plain text, do not run this test.")
 
 	client := c.ProdClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	userName := "Test User"
 
@@ -20,10 +20,7 @@ func (c *ClientTests) TestUserCreate() {
 			Name: &userName,
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.User{}), reflect.TypeOf(user))
 	assert.True(strings.HasPrefix(user.ID, "user_"))
@@ -32,19 +29,13 @@ func (c *ClientTests) TestUserCreate() {
 
 func (c *ClientTests) TestUserRetrieve() {
 	client := c.ProdClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	authenticatedUser, err := client.RetrieveMe()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedUser, err := client.GetUser(authenticatedUser.Children[0].ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.User{}), reflect.TypeOf(retrievedUser))
 	assert.True(strings.HasPrefix(retrievedUser.ID, "user_"))
@@ -52,13 +43,10 @@ func (c *ClientTests) TestUserRetrieve() {
 
 func (c *ClientTests) TestUserRetrieveMe() {
 	client := c.ProdClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	user, err := client.RetrieveMe()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.User{}), reflect.TypeOf(user))
 	assert.True(strings.HasPrefix(user.ID, "user_"))
@@ -66,13 +54,10 @@ func (c *ClientTests) TestUserRetrieveMe() {
 
 func (c *ClientTests) TestUserUpdate() {
 	client := c.ProdClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	user, err := client.RetrieveMe()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	test_phone := "5555555555"
 
@@ -82,10 +67,7 @@ func (c *ClientTests) TestUserUpdate() {
 			PhoneNumber: &test_phone,
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.User{}), reflect.TypeOf(updatedUser))
 	assert.True(strings.HasPrefix(updatedUser.ID, "user_"))
@@ -94,15 +76,12 @@ func (c *ClientTests) TestUserUpdate() {
 
 func (c *ClientTests) TestUserUpdateBrand() {
 	client := c.ProdClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	color := "#123456"
 
 	user, err := client.RetrieveMe()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	brand, err := client.UpdateBrand(
 		map[string]interface{}{
@@ -110,10 +89,7 @@ func (c *ClientTests) TestUserUpdateBrand() {
 		},
 		user.ID,
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Brand{}), reflect.TypeOf(brand))
 	assert.True(strings.HasPrefix(brand.ID, "brd_"))
@@ -132,16 +108,10 @@ func (c *ClientTests) TestUserDelete() {
 			Name: &userName,
 		},
 	)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	err = client.DeleteUser(user.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	require.NoError(err)
 }
@@ -149,13 +119,10 @@ func (c *ClientTests) TestUserDelete() {
 func (c *ClientTests) TestUserApiKeysAll() {
 	c.T().Skip("API keys are returned as plaintext, do not run this test.")
 	client := c.ProdClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	apiKeys, err := client.GetAPIKeys()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.NotNil(apiKeys)
 }

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -12,20 +12,14 @@ func (c *ClientTests) TestWebhookCreate() {
 	assert, require := c.Assert(), c.Require()
 
 	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(webhook))
 	assert.True(strings.HasPrefix(webhook.ID, "hook_"))
 	assert.Equal(c.fixture.WebhookUrl(), webhook.URL)
 
 	err = client.DeleteWebhook(webhook.ID) // we are deleting the webhook here so we don't keep sending events to a dead webhook.
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	require.NoError(err)
 }
@@ -35,38 +29,26 @@ func (c *ClientTests) TestWebhookRetrieve() {
 	assert, require := c.Assert(), c.Require()
 
 	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	retrievedWebhook, err := client.GetWebhook(webhook.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(retrievedWebhook))
 	assert.Equal(webhook, retrievedWebhook)
 
 	err = client.DeleteWebhook(retrievedWebhook.ID) // we are deleting the webhook here, so we don't keep sending events to a dead webhook.
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	require.NoError(err)
 }
 
 func (c *ClientTests) TestWebhookAll() {
 	client := c.TestClient()
-	assert := c.Assert()
+	assert, require := c.Assert(), c.Require()
 
 	webhooks, err := client.ListWebhooks()
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.LessOrEqual(len(webhooks), c.fixture.pageSize())
 	for _, webhook := range webhooks {
@@ -79,20 +61,14 @@ func (c *ClientTests) TestWebhookDelete() {
 	assert, require := c.Assert(), c.Require()
 
 	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(webhook))
 	assert.True(strings.HasPrefix(webhook.ID, "hook_"))
 	assert.Equal(c.fixture.WebhookUrl(), webhook.URL)
 
 	err = client.DeleteWebhook(webhook.ID)
-	if err != nil {
-		c.T().Error(err)
-		return
-	}
+	require.NoError(err)
 
 	// This endpoint/method does not return anything, just make sure the request doesn't fail
 	require.NoError(err)


### PR DESCRIPTION
# Description

I was moving too quickly in my previous attempt to catch errors in tests. There is a more "Golang" approach to this by using `require.NoError(err)` which I'm switching to here. Accomplishes the same thing with much less code and is more bullet proof.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Re-ran tests to ensure this works, tweaked a fixture to prove that errors will still be raised with the new syntax, eg:

```
    --- FAIL: TestClient/TestShipmentSmartrate (0.00s)
        shipment_test.go:144: 
                Error Trace:    shipment_test.go:144
                Error:          Received unexpected error:
                                Post "https://api.easypost.com/v2/shipments": Requested interaction not found
                Test:           TestClient/TestShipmentSmartrate
```

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
