### PR TITLE
fix: docs link in README to point to new official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ func main() {
 
 ## Documentation
 
-See the above example, or view the [GoDoc](https://pkg.go.dev/github.com/EasyPost/easypost-go) for more details.
+API Documentation can be found at: <https://easypost.com/docs/api>. Alternatively, you can view the [GoDoc](https://pkg.go.dev/github.com/EasyPost/easypost-go).
 
 Upgrading major versions of this project? Refer to the [Upgrade Guide](UPGRADE_GUIDE.md).
 


### PR DESCRIPTION
# Description

We are about to launch our official Golang docs and as such, the link in the README needs to get updated.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
