### PR TITLE
Webhook secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add new lowest rate functions for Shipments, Orders and Pickups
 - Add new lowest smartrate functions for Shipments
 - Adds OS details to the User-Agent header
+- Add support for webhook secrets
 
 ## v2.3.0 (2022-04-13)
 

--- a/tests/cassettes/TestWebhookAll.yaml
+++ b/tests/cassettes/TestWebhookAll.yaml
@@ -30,27 +30,25 @@ interactions:
       - max-age=31536000; includeSubDomains; preload
       X-Backend:
       - easypost
-      X-Canary:
-      - direct
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 19577bfa628f974de78b9ba7006bce4d
+      - 1e90ffad62bb3867ec860bbf003136d0
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb7nuq
+      - bigweb1nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 570dfcbc0a
-      - extlb1nuq fc4d5d217f
+      - intlb2nuq a732742a48
+      - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.023586"
+      - "0.021115"
       X-Version-Label:
-      - easypost-202205252316-1f08f7be53-master
+      - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/tests/cassettes/TestWebhookCreateWithSecret.yaml
+++ b/tests/cassettes/TestWebhookCreateWithSecret.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"webhook":{"url":"http://example.com"}}'
+    body: '{"webhook":{"url":"http://example.com","webhook_secret":"this_is_a_secret"}}'
     form: {}
     headers:
       Authorization:
@@ -14,14 +14,14 @@ interactions:
     url: https://api.easypost.com/v2/webhooks
     method: POST
   response:
-    body: '{"id":"hook_a1805600f70611ecb2fd757d7720710f","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:39Z","disabled_at":null}'
+    body: '{"id":"hook_a1e51798f70611ec9cae051c03fe0089","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:40Z","disabled_at":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"172eecd4b9b7babdd24afca2c5fc6154"
+      - W/"842a1376db529e54b72f49dfdd9a6c27"
       Expires:
       - "0"
       Pragma:
@@ -37,18 +37,18 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 1e90ffad62bb3867ec860bbf003136d6
+      - 1e90ffad62bb3867ec860bbf00313706
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb3nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq a732742a48
+      - intlb1nuq a732742a48
       - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.149063"
+      - "0.664544"
       X-Version-Label:
       - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
@@ -64,7 +64,7 @@ interactions:
       - REDACTED
       User-Agent:
       - REDACTED
-    url: https://api.easypost.com/v2/webhooks/hook_a1805600f70611ecb2fd757d7720710f
+    url: https://api.easypost.com/v2/webhooks/hook_a1e51798f70611ec9cae051c03fe0089
     method: DELETE
   response:
     body: '{}'
@@ -90,18 +90,18 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 1e90ffad62bb3867ec860bbf003136ea
+      - 1e90ffad62bb3868ec860bbf00313741
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb3nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq a732742a48
+      - intlb2nuq a732742a48
       - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.294175"
+      - "0.327748"
       X-Version-Label:
       - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:

--- a/tests/cassettes/TestWebhookDelete.yaml
+++ b/tests/cassettes/TestWebhookDelete.yaml
@@ -14,14 +14,14 @@ interactions:
     url: https://api.easypost.com/v2/webhooks
     method: POST
   response:
-    body: '{"id":"hook_54ce2bf4dd0511ec9edb6febfe807306","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-05-26T15:05:51Z","disabled_at":null}'
+    body: '{"id":"hook_a287d60ef70611ecbb3a2b68eb595361","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:41Z","disabled_at":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"2129c4d54403ed8f2ec6c5420853e05c"
+      - W/"5e91e3034c147626cfe52b0eb1571392"
       Expires:
       - "0"
       Pragma:
@@ -32,27 +32,25 @@ interactions:
       - max-age=31536000; includeSubDomains; preload
       X-Backend:
       - easypost
-      X-Canary:
-      - direct
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 19577bfa628f974ee78b9ba7006bceb9
+      - 1e90ffad62bb3868ec860bbf0031375d
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb7nuq
+      - bigweb2nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 570dfcbc0a
-      - extlb1nuq fc4d5d217f
+      - intlb2nuq a732742a48
+      - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.150224"
+      - "0.106082"
       X-Version-Label:
-      - easypost-202205252316-1f08f7be53-master
+      - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created
@@ -66,7 +64,7 @@ interactions:
       - REDACTED
       User-Agent:
       - REDACTED
-    url: https://api.easypost.com/v2/webhooks/hook_54ce2bf4dd0511ec9edb6febfe807306
+    url: https://api.easypost.com/v2/webhooks/hook_a287d60ef70611ecbb3a2b68eb595361
     method: DELETE
   response:
     body: '{}'
@@ -92,20 +90,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 19577bfa628f974fe78b9ba7006bceda
+      - 1e90ffad62bb3869ec860bbf0031376e
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb3nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 570dfcbc0a
-      - extlb1nuq fc4d5d217f
+      - intlb1nuq a732742a48
+      - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.445832"
+      - "0.264819"
       X-Version-Label:
-      - easypost-202205252316-1f08f7be53-master
+      - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/tests/cassettes/TestWebhookRetrieve.yaml
+++ b/tests/cassettes/TestWebhookRetrieve.yaml
@@ -14,14 +14,14 @@ interactions:
     url: https://api.easypost.com/v2/webhooks
     method: POST
   response:
-    body: '{"id":"hook_555fae1cdd0511ecaa247d86f4c6803e","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-05-26T15:05:52Z","disabled_at":null}'
+    body: '{"id":"hook_a2eeeeacf70611eca96b75a57379e390","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:42Z","disabled_at":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"9f8d3a561562df718b0599a77f69d68b"
+      - W/"eeaea79dcff5d58574180d9a3dcbc1b0"
       Expires:
       - "0"
       Pragma:
@@ -37,20 +37,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 19577bfa628f974fe78b9ba7006bcf20
+      - 1e90ffad62bb3869ec860bbf0031377d
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb3nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 570dfcbc0a
-      - extlb1nuq fc4d5d217f
+      - intlb2nuq a732742a48
+      - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.222968"
+      - "0.256449"
       X-Version-Label:
-      - easypost-202205252316-1f08f7be53-master
+      - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created
@@ -64,17 +64,17 @@ interactions:
       - REDACTED
       User-Agent:
       - REDACTED
-    url: https://api.easypost.com/v2/webhooks/hook_555fae1cdd0511ecaa247d86f4c6803e
+    url: https://api.easypost.com/v2/webhooks/hook_a2eeeeacf70611eca96b75a57379e390
     method: GET
   response:
-    body: '{"id":"hook_555fae1cdd0511ecaa247d86f4c6803e","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-05-26T15:05:52Z","disabled_at":null}'
+    body: '{"id":"hook_a2eeeeacf70611eca96b75a57379e390","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:42Z","disabled_at":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"9f8d3a561562df718b0599a77f69d68b"
+      - W/"eeaea79dcff5d58574180d9a3dcbc1b0"
       Expires:
       - "0"
       Pragma:
@@ -90,20 +90,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 19577bfa628f9750e78b9ba7006bcf51
+      - 1e90ffad62bb3869ec860bbf0031378d
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb2nuq
+      - bigweb3nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 570dfcbc0a
-      - extlb1nuq fc4d5d217f
+      - intlb2nuq a732742a48
+      - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.024585"
+      - "0.024764"
       X-Version-Label:
-      - easypost-202205252316-1f08f7be53-master
+      - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -117,7 +117,7 @@ interactions:
       - REDACTED
       User-Agent:
       - REDACTED
-    url: https://api.easypost.com/v2/webhooks/hook_555fae1cdd0511ecaa247d86f4c6803e
+    url: https://api.easypost.com/v2/webhooks/hook_a2eeeeacf70611eca96b75a57379e390
     method: DELETE
   response:
     body: '{}'
@@ -143,20 +143,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 19577bfa628f9750e78b9ba7006bcf5d
+      - 1e90ffad62bb3869ec860bbf00313793
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb4nuq
+      - bigweb1nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 570dfcbc0a
-      - extlb1nuq fc4d5d217f
+      - intlb2nuq a732742a48
+      - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.390843"
+      - "0.367184"
       X-Version-Label:
-      - easypost-202205252316-1f08f7be53-master
+      - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/tests/cassettes/TestWebhookUpdate.yaml
+++ b/tests/cassettes/TestWebhookUpdate.yaml
@@ -14,14 +14,14 @@ interactions:
     url: https://api.easypost.com/v2/webhooks
     method: POST
   response:
-    body: '{"id":"hook_5bad9922e11111ec951811f3214e8ece","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-05-31T18:42:01Z","disabled_at":null}'
+    body: '{"id":"hook_a36a6410f70611ec963819d87a8c2384","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:43Z","disabled_at":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"c69f9b563766a01b3b8218f9fc5295f7"
+      - W/"2142675ec0280d4efbb04e04f84ab2e6"
       Expires:
       - "0"
       Pragma:
@@ -37,45 +37,46 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 19be063a62966178f2d49d9f000260c9
+      - 1e90ffad62bb386aec860bbf003137be
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb9nuq
+      - bigweb3nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq 570dfcbc0a
-      - intlb2wdc 570dfcbc0a
-      - extlb1wdc 0910011e7e
+      - intlb1nuq a732742a48
+      - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.141282"
+      - "0.150995"
       X-Version-Label:
-      - easypost-202205272233-af67cc8d0c-master
+      - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: ""
+    body: '{"webhook":{}}'
     form: {}
     headers:
       Authorization:
       - REDACTED
+      Content-Type:
+      - application/json
       User-Agent:
       - REDACTED
-    url: https://api.easypost.com/v2/webhooks/hook_5bad9922e11111ec951811f3214e8ece
+    url: https://api.easypost.com/v2/webhooks/hook_a36a6410f70611ec963819d87a8c2384
     method: PATCH
   response:
-    body: '{"id":"hook_5bad9922e11111ec951811f3214e8ece","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-05-31T18:42:01Z","disabled_at":null}'
+    body: '{"id":"hook_a36a6410f70611ec963819d87a8c2384","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:43Z","disabled_at":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"c69f9b563766a01b3b8218f9fc5295f7"
+      - W/"2142675ec0280d4efbb04e04f84ab2e6"
       Expires:
       - "0"
       Pragma:
@@ -91,21 +92,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 19be063a62966179f2d49d9f000260ee
+      - 1e90ffad62bb386aec860bbf003137ce
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb9nuq
+      - bigweb3nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 570dfcbc0a
-      - intlb2wdc 570dfcbc0a
-      - extlb1wdc 0910011e7e
+      - intlb1nuq a732742a48
+      - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.456248"
+      - "0.455305"
       X-Version-Label:
-      - easypost-202205272233-af67cc8d0c-master
+      - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created
@@ -119,7 +119,7 @@ interactions:
       - REDACTED
       User-Agent:
       - REDACTED
-    url: https://api.easypost.com/v2/webhooks/hook_5bad9922e11111ec951811f3214e8ece
+    url: https://api.easypost.com/v2/webhooks/hook_a36a6410f70611ec963819d87a8c2384
     method: DELETE
   response:
     body: '{}'
@@ -145,21 +145,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 19be063a6296617af2d49d9f00026133
+      - 1e90ffad62bb386bec860bbf003137ee
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb8nuq
+      - bigweb3nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq 570dfcbc0a
-      - intlb1wdc 570dfcbc0a
-      - extlb1wdc 0910011e7e
+      - intlb1nuq a732742a48
+      - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.300123"
+      - "0.371396"
       X-Version-Label:
-      - easypost-202205272233-af67cc8d0c-master
+      - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/tests/cassettes/TestWebhookUpdateWithSecret.yaml
+++ b/tests/cassettes/TestWebhookUpdateWithSecret.yaml
@@ -14,14 +14,14 @@ interactions:
     url: https://api.easypost.com/v2/webhooks
     method: POST
   response:
-    body: '{"id":"hook_a1805600f70611ecb2fd757d7720710f","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:39Z","disabled_at":null}'
+    body: '{"id":"hook_a41606b2f70611eca14b695f6ce7a466","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:44Z","disabled_at":null}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"172eecd4b9b7babdd24afca2c5fc6154"
+      - W/"0fee6cbafc30d008c174a489f9af1c0f"
       Expires:
       - "0"
       Pragma:
@@ -37,18 +37,73 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 1e90ffad62bb3867ec860bbf003136d6
+      - 1e90ffad62bb386bec860bbf0031380a
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb9nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq a732742a48
+      - intlb1nuq a732742a48
       - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.149063"
+      - "0.113046"
+      X-Version-Label:
+      - easypost-202206272314-c14e8f7f31-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"webhook":{"webhook_secret":"this_is_a_secret"}}'
+    form: {}
+    headers:
+      Authorization:
+      - REDACTED
+      Content-Type:
+      - application/json
+      User-Agent:
+      - REDACTED
+    url: https://api.easypost.com/v2/webhooks/hook_a41606b2f70611eca14b695f6ce7a466
+    method: PATCH
+  response:
+    body: '{"id":"hook_a41606b2f70611eca14b695f6ce7a466","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-06-28T17:20:44Z","disabled_at":null}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"0fee6cbafc30d008c174a489f9af1c0f"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 1e90ffad62bb386bec860bbf00313816
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb8nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq a732742a48
+      - extlb1nuq 403f17ff97
+      X-Runtime:
+      - "0.456353"
       X-Version-Label:
       - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:
@@ -64,7 +119,7 @@ interactions:
       - REDACTED
       User-Agent:
       - REDACTED
-    url: https://api.easypost.com/v2/webhooks/hook_a1805600f70611ecb2fd757d7720710f
+    url: https://api.easypost.com/v2/webhooks/hook_a41606b2f70611eca14b695f6ce7a466
     method: DELETE
   response:
     body: '{}'
@@ -90,18 +145,18 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 1e90ffad62bb3867ec860bbf003136ea
+      - 1e90ffad62bb386cec860bbf00313842
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb6nuq
+      - bigweb5nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
       - intlb1nuq a732742a48
       - extlb1nuq 403f17ff97
       X-Runtime:
-      - "0.294175"
+      - "0.284950"
       X-Version-Label:
       - easypost-202206272314-c14e8f7f31-master
       X-Xss-Protection:

--- a/tests/fixture_test.go
+++ b/tests/fixture_test.go
@@ -52,6 +52,10 @@ func (fixture *Fixture) WebhookUrl() string {
 	return "http://example.com"
 }
 
+func (fixture *Fixture) WebhookSecret() string {
+	return "this_is_a_secret"
+}
+
 func (fixture *Fixture) BasicAddress() *easypost.Address {
 	return &easypost.Address{
 		Name:    "Jack Sparrow",

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -89,3 +89,34 @@ func (c *ClientTests) TestWebhookUpdate() {
 	err = client.DeleteWebhook(updatedWebhook.ID)
 	require.NoError(err)
 }
+
+func (c *ClientTests) TestWebhookCreateWithSecret() {
+	client := c.TestClient()
+	assert, require := c.Assert(), c.Require()
+
+	webhook, err := client.CreateWebhookWithSecret(c.fixture.WebhookUrl(), c.fixture.WebhookSecret())
+	require.NoError(err)
+
+	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(webhook))
+	assert.True(strings.HasPrefix(webhook.ID, "hook_"))
+	assert.Equal(c.fixture.WebhookUrl(), webhook.URL)
+
+	err = client.DeleteWebhook(webhook.ID) // we are deleting the webhook here, so we don't keep sending events to a dead webhook.
+	require.NoError(err)
+}
+
+func (c *ClientTests) TestWebhookUpdateWithSecret() {
+	client := c.TestClient()
+	assert, require := c.Assert(), c.Require()
+
+	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
+	require.NoError(err)
+
+	updatedWebhook, err := client.UpdateWebhook(webhook.ID, &easypost.UpdateWebhookOptions{WebhookSecret: c.fixture.WebhookSecret()})
+	require.NoError(err)
+
+	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(updatedWebhook))
+
+	err = client.DeleteWebhook(updatedWebhook.ID)
+	require.NoError(err)
+}

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -81,7 +81,7 @@ func (c *ClientTests) TestWebhookUpdate() {
 	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
 	require.NoError(err)
 
-	updatedWebhook, err := client.EnableWebhook(webhook.ID)
+	updatedWebhook, err := client.UpdateWebhook(webhook.ID, &easypost.UpdateWebhookOptions{})
 	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(updatedWebhook))

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -78,10 +78,13 @@ func (c *ClientTests) TestWebhookUpdate() {
 	client := c.TestClient()
 	assert, require := c.Assert(), c.Require()
 
-	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
+	webhook, err := client.CreateWebhookWithDetails(
+		&easypost.CreateUpdateWebhookOptions{
+			URL: c.fixture.WebhookUrl(),
+		})
 	require.NoError(err)
 
-	updatedWebhook, err := client.UpdateWebhook(webhook.ID, &easypost.UpdateWebhookOptions{})
+	updatedWebhook, err := client.UpdateWebhook(webhook.ID, &easypost.CreateUpdateWebhookOptions{})
 	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(updatedWebhook))
@@ -94,7 +97,11 @@ func (c *ClientTests) TestWebhookCreateWithSecret() {
 	client := c.TestClient()
 	assert, require := c.Assert(), c.Require()
 
-	webhook, err := client.CreateWebhookWithSecret(c.fixture.WebhookUrl(), c.fixture.WebhookSecret())
+	webhook, err := client.CreateWebhookWithDetails(
+		&easypost.CreateUpdateWebhookOptions{
+			URL:           c.fixture.WebhookUrl(),
+			WebhookSecret: c.fixture.WebhookSecret(),
+		})
 	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(webhook))
@@ -109,10 +116,16 @@ func (c *ClientTests) TestWebhookUpdateWithSecret() {
 	client := c.TestClient()
 	assert, require := c.Assert(), c.Require()
 
-	webhook, err := client.CreateWebhook(c.fixture.WebhookUrl())
+	webhook, err := client.CreateWebhookWithDetails(
+		&easypost.CreateUpdateWebhookOptions{
+			URL: c.fixture.WebhookUrl(),
+		})
 	require.NoError(err)
 
-	updatedWebhook, err := client.UpdateWebhook(webhook.ID, &easypost.UpdateWebhookOptions{WebhookSecret: c.fixture.WebhookSecret()})
+	updatedWebhook, err := client.UpdateWebhook(webhook.ID,
+		&easypost.CreateUpdateWebhookOptions{
+			WebhookSecret: c.fixture.WebhookSecret(),
+		})
 	require.NoError(err)
 
 	assert.Equal(reflect.TypeOf(&easypost.Webhook{}), reflect.TypeOf(updatedWebhook))

--- a/webhook.go
+++ b/webhook.go
@@ -7,14 +7,21 @@ import (
 
 // A Webhook represents an EasyPost webhook callback URL.
 type Webhook struct {
-	ID         string     `json:"id,omitempty"`
-	Object     string     `json:"object,omitempty"`
-	Mode       string     `json:"mode,omitempty"`
-	URL        string     `json:"url,omitempty"`
-	DisabledAt *time.Time `json:"disabled_at,omitempty"`
+	ID            string     `json:"id,omitempty"`
+	Object        string     `json:"object,omitempty"`
+	Mode          string     `json:"mode,omitempty"`
+	URL           string     `json:"url,omitempty"`
+	DisabledAt    *time.Time `json:"disabled_at,omitempty"`
+	WebhookSecret string     `json:"webhook_secret,omitempty"`
 }
 
-type createWebhookRequest struct {
+// UpdateWebhookOptions is used to specify parameters for updating EasyPost webhooks.
+type UpdateWebhookOptions struct {
+	URL           string `json:"url,omitempty"`
+	WebhookSecret string `json:"webhook_secret,omitempty"`
+}
+
+type createUpdateWebhookRequest struct {
 	Webhook *Webhook `json:"webhook,omitempty"`
 }
 
@@ -27,10 +34,23 @@ func (c *Client) CreateWebhook(u string) (out *Webhook, err error) {
 	return c.CreateWebhookWithContext(context.Background(), u)
 }
 
+// CreateWebhookWithSecret creates a new webhook with the given URL and secret.
+func (c *Client) CreateWebhookWithSecret(u string, s string) (out *Webhook, err error) {
+	return c.CreateWebhookWithSecretWithContext(context.Background(), u, s)
+}
+
 // CreateWebhookWithContext performs the same operation as CreateWebhook, but
 // allows specifying a context that can interrupt the request.
 func (c *Client) CreateWebhookWithContext(ctx context.Context, u string) (out *Webhook, err error) {
-	req := &createWebhookRequest{Webhook: &Webhook{URL: u}}
+	req := &createUpdateWebhookRequest{Webhook: &Webhook{URL: u}}
+	err = c.post(ctx, "webhooks", req, &out)
+	return
+}
+
+// CreateWebhookWithSecretWithContext performs the same operation as CreateWebhookWithSecret, but
+// allows specifying a context that can interrupt the request.
+func (c *Client) CreateWebhookWithSecretWithContext(ctx context.Context, u string, s string) (out *Webhook, err error) {
+	req := &createUpdateWebhookRequest{Webhook: &Webhook{URL: u, WebhookSecret: s}}
 	err = c.post(ctx, "webhooks", req, &out)
 	return
 }
@@ -60,15 +80,29 @@ func (c *Client) GetWebhookWithContext(ctx context.Context, webhookID string) (o
 	return
 }
 
+// Deprecated: Use UpdateWebhook instead.
 // EnableWebhook re-enables a disabled webhook.
 func (c *Client) EnableWebhook(webhookID string) (out *Webhook, err error) {
-	return c.EnableWebhookWithContext(context.Background(), webhookID)
+	return c.UpdateWebhook(webhookID, &UpdateWebhookOptions{})
 }
 
+// Deprecated: Use UpdateWebhookWithContext instead.
 // EnableWebhookWithContext performs the same operation as EnableWebhook, but
 // allows specifying a context that can interrupt the request.
 func (c *Client) EnableWebhookWithContext(ctx context.Context, webhookID string) (out *Webhook, err error) {
-	err = c.patch(ctx, "webhooks/"+webhookID, nil, &out)
+	return c.UpdateWebhookWithContext(ctx, webhookID, &UpdateWebhookOptions{})
+}
+
+// UpdateWebhook updates a webhook. Automatically re-enables webhook if it is disabled.
+func (c *Client) UpdateWebhook(webhookID string, data *UpdateWebhookOptions) (out *Webhook, err error) {
+	return c.UpdateWebhookWithContext(context.Background(), webhookID, data)
+}
+
+// UpdateWebhookWithContext performs the same operation as UpdateWebhook, but
+// allows specifying a context that can interrupt the request.
+func (c *Client) UpdateWebhookWithContext(ctx context.Context, webhookID string, data *UpdateWebhookOptions) (out *Webhook, err error) {
+	req := &createUpdateWebhookRequest{Webhook: &Webhook{URL: data.URL, WebhookSecret: data.WebhookSecret}}
+	err = c.patch(ctx, "webhooks/"+webhookID, req, &out)
 	return
 }
 


### PR DESCRIPTION
# Description

- Add support for webhook secrets when creating/updating a webhook
- `EnableWebhook` deprecated
- `CreateWebhook` deprecated

# Testing

- New unit tests for secret testing
- Recorded new unit test cassettes
- All tests pass

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
