### PR TITLE
fix: run coverage on CI to fail when under

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: install
         run: make install
       - name: run tests
-        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 PARTNER_USER_PROD_API_KEY=123 REFERRAL_USER_PROD_API_KEY=123 make test
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 PARTNER_USER_PROD_API_KEY=123 REFERRAL_USER_PROD_API_KEY=123 make coverage
       - name: Run Gosec
         uses: securego/gosec@master
         with:

--- a/tests/bootstrap_test.go
+++ b/tests/bootstrap_test.go
@@ -288,7 +288,7 @@ func TestMain(m *testing.M) {
 
 	// Fail test suite below desired coverage
 	// `testSuite = 0` means it passed, CoverMode will be non empty if run with -cover
-	coverageMinPercentage := 0.75 // TODO: This number for whatever reason is about ~5% lower than what the CLI reports which is the real value
+	coverageMinPercentage := 0.72 // TODO: This number for whatever reason is about ~5% lower than what the CLI reports which is the real value
 	if testSuite == 0 && testing.CoverMode() != "" {
 		coverage := testing.Coverage()
 		if coverage < coverageMinPercentage {


### PR DESCRIPTION
# Description

Runs coverage on CI so we fail the build when coverage doesn't meet the criteria.

Drops the percentage by 3% due to reporting issues between CI and local.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
