### PR TITLE
New test utility to mock HTTP requests/responses

### DIFF
--- a/mocking.go
+++ b/mocking.go
@@ -1,0 +1,51 @@
+package easypost
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+type MockRequestMatchRule struct {
+	Method          string
+	UrlRegexPattern string
+}
+
+type MockRequestResponseInfo struct {
+	StatusCode int
+	Body       string
+}
+
+func (r *MockRequestResponseInfo) MockBody() io.ReadCloser {
+	return ioutil.NopCloser(strings.NewReader(r.Body))
+}
+
+type MockRequest struct {
+	MatchRule    MockRequestMatchRule
+	ResponseInfo MockRequestResponseInfo
+}
+
+func (r *MockRequestResponseInfo) AsResponse() *http.Response {
+	return &http.Response{
+		Status:        http.StatusText(r.StatusCode),
+		StatusCode:    r.StatusCode,
+		Body:          r.MockBody(),
+		ContentLength: int64(len(r.Body)),
+		Header:        nil,
+		Request:       nil,
+	}
+}
+
+func (c *Client) findMatchingMockRequest(req *http.Request) *http.Response {
+	for _, mockReq := range c.MockRequests {
+		url := req.URL.String()
+		methodMatch := mockReq.MatchRule.Method == "" || mockReq.MatchRule.Method == req.Method
+		urlMatch, _ := regexp.MatchString(mockReq.MatchRule.UrlRegexPattern, url)
+		if methodMatch && urlMatch {
+			return mockReq.ResponseInfo.AsResponse()
+		}
+	}
+	return nil
+}

--- a/tests/billing_test.go
+++ b/tests/billing_test.go
@@ -2,10 +2,67 @@ package easypost_test
 
 import "github.com/EasyPost/easypost-go/v2"
 
-func (c *ClientTests) TestDeletePaymentMethod() {
-	c.T().Skip("Skipping due to the lack of an available real payment method in tests")
+func GetMockRequests() []easypost.MockRequest {
+	return []easypost.MockRequest{
+		{
+			MatchRule: easypost.MockRequestMatchRule{
+				Method:          "POST",
+				UrlRegexPattern: "v2\\/bank_accounts\\/\\S*\\/charges$",
+			},
+			ResponseInfo: easypost.MockRequestResponseInfo{
+				StatusCode: 200,
+				Body:       `{}`,
+			},
+		},
+		{
+			MatchRule: easypost.MockRequestMatchRule{
+				Method:          "POST",
+				UrlRegexPattern: "v2\\/credit_cards\\/\\S*\\/charges$",
+			},
+			ResponseInfo: easypost.MockRequestResponseInfo{
+				StatusCode: 200,
+				Body:       `{}`,
+			},
+		},
+		{
+			MatchRule: easypost.MockRequestMatchRule{
+				Method:          "DELETE",
+				UrlRegexPattern: "v2\\/bank_accounts\\/\\S*$",
+			},
+			ResponseInfo: easypost.MockRequestResponseInfo{
+				StatusCode: 200,
+				Body:       `{}`,
+			},
+		},
+		{
+			MatchRule: easypost.MockRequestMatchRule{
+				Method:          "DELETE",
+				UrlRegexPattern: "v2\\/credit_cards\\/\\S*$",
+			},
+			ResponseInfo: easypost.MockRequestResponseInfo{
+				StatusCode: 200,
+				Body:       `{}`,
+			},
+		},
+		{
+			MatchRule: easypost.MockRequestMatchRule{
+				Method:          "GET",
+				UrlRegexPattern: "v2\\/payment_methods$",
+			},
+			ResponseInfo: easypost.MockRequestResponseInfo{
+				StatusCode: 200,
+				Body:       `{"id": "summary_123", "primary_payment_method": {"id": "card_123", "last4": "1234"}, "secondary_payment_method": {"id": "bank_123", "bank_name": "Mock Bank"}}`,
+			},
+		},
+	}
+}
 
-	client := c.ProdClient()
+func (c *ClientTests) TestDeletePaymentMethod() {
+	// c.T().Skip("Skipping due to the lack of an available real payment method in tests")
+
+	mockRequests := GetMockRequests()
+
+	client := c.MockClient(mockRequests)
 	require := c.Require()
 
 	err := client.DeletePaymentMethod(easypost.PrimaryPaymentMethodPriority)
@@ -13,9 +70,11 @@ func (c *ClientTests) TestDeletePaymentMethod() {
 }
 
 func (c *ClientTests) TestFundWallet() {
-	c.T().Skip("Skipping due to the lack of an available real payment method in tests")
+	// c.T().Skip("Skipping due to the lack of an available real payment method in tests")
 
-	client := c.ProdClient()
+	mockRequests := GetMockRequests()
+
+	client := c.MockClient(mockRequests)
 	require := c.Require()
 
 	err := client.FundWallet("2000", easypost.PrimaryPaymentMethodPriority)
@@ -23,9 +82,11 @@ func (c *ClientTests) TestFundWallet() {
 }
 
 func (c *ClientTests) TestRetrievePaymentMethods() {
-	c.T().Skip("Skipping due to having to manually add and remove a payment method from the account")
+	// c.T().Skip("Skipping due to having to manually add and remove a payment method from the account")
 
-	client := c.ProdClient()
+	mockRequests := GetMockRequests()
+
+	client := c.MockClient(mockRequests)
 	assert, require := c.Assert(), c.Require()
 
 	paymentMethods, err := client.RetrievePaymentMethods()

--- a/tests/bootstrap_test.go
+++ b/tests/bootstrap_test.go
@@ -277,6 +277,15 @@ func (c *ClientTests) PartnerClient() *easypost.Client {
 	}
 }
 
+// MockClient sets up the mock client object to be used in the test
+func (c *ClientTests) MockClient(requests []easypost.MockRequest) *easypost.Client {
+	return &easypost.Client{
+		APIKey:       "cannot_be_blank",
+		Client:       &http.Client{Transport: c.recorder},
+		MockRequests: requests,
+	}
+}
+
 // TestClient runs the entire test suite
 func TestClient(t *testing.T) {
 	suite.Run(t, new(ClientTests))


### PR DESCRIPTION
# Description

Spurred by [this PR](https://github.com/EasyPost/easypost-go/pull/136) and based on the implementation in [C#](https://github.com/EasyPost/easypost-csharp/blob/master/EasyPost.Tests/ServicesTests/BillingServiceTest.cs#L21) and [Node](https://github.com/EasyPost/easypost-node/pull/317), this adds the ability to mock requests.

This is accomplished by adding a list of `MockRequest` objects into the EasyPost client. If this property is set, the client will ONLY use mock requests (any request passed in that is not a configured mock request will throw an exception).

# Testing

- Use mocking in billing test, re-enable billing tests

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
