### PR TITLE
Fix client swapping for Stripe API calls, re-enable referral credit card test

### DIFF
--- a/referral.go
+++ b/referral.go
@@ -123,8 +123,6 @@ func (c *Client) retrieveEasypostStripeApiKey(ctx context.Context) (out *stripeA
 }
 
 func (c *Client) createStripeToken(ctx context.Context, stripeApiKey string, creditCardOptions *CreditCardOptions) (out *stripeTokenResponse, err error) {
-	client := http.Client{}
-
 	data := url.Values{}
 	data.Set("card[number]", creditCardOptions.Number)
 	data.Set("card[exp_month]", creditCardOptions.ExpMonth)
@@ -139,7 +137,7 @@ func (c *Client) createStripeToken(ctx context.Context, stripeApiKey string, cre
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Authorization", "Bearer "+stripeApiKey)
 
-	resp, err := client.Do(req)
+	resp, err := c.client().Do(req) // use the current client's inner http.Client (configured to record) for the one-off request
 	if err != nil {
 		return nil, err
 	}
@@ -164,6 +162,7 @@ func (c *Client) createStripeToken(ctx context.Context, stripeApiKey string, cre
 func (c *Client) createEasypostCreditCard(ctx context.Context, referralCustomerApiKey string, stripeToken string, priority PaymentMethodPriority) (out *PaymentMethodObject, err error) {
 	client := &Client{
 		APIKey: referralCustomerApiKey,
+		Client: c.client(), // pass the current client's inner http.Client (configured to record) to the new client
 	}
 
 	priorityString := ""

--- a/tests/billing_test.go
+++ b/tests/billing_test.go
@@ -2,7 +2,7 @@ package easypost_test
 
 import "github.com/EasyPost/easypost-go/v2"
 
-func GetMockRequests() []easypost.MockRequest {
+func GetBillingMockRequests() []easypost.MockRequest {
 	return []easypost.MockRequest{
 		{
 			MatchRule: easypost.MockRequestMatchRule{
@@ -58,7 +58,7 @@ func GetMockRequests() []easypost.MockRequest {
 }
 
 func (c *ClientTests) TestDeletePaymentMethod() {
-	mockRequests := GetMockRequests()
+	mockRequests := GetBillingMockRequests()
 
 	client := c.MockClient(mockRequests)
 	require := c.Require()
@@ -68,7 +68,7 @@ func (c *ClientTests) TestDeletePaymentMethod() {
 }
 
 func (c *ClientTests) TestFundWallet() {
-	mockRequests := GetMockRequests()
+	mockRequests := GetBillingMockRequests()
 
 	client := c.MockClient(mockRequests)
 	require := c.Require()
@@ -78,7 +78,7 @@ func (c *ClientTests) TestFundWallet() {
 }
 
 func (c *ClientTests) TestRetrievePaymentMethods() {
-	mockRequests := GetMockRequests()
+	mockRequests := GetBillingMockRequests()
 
 	client := c.MockClient(mockRequests)
 	assert, require := c.Assert(), c.Require()

--- a/tests/bootstrap_test.go
+++ b/tests/bootstrap_test.go
@@ -26,7 +26,7 @@ var (
 	ProdAPIKey string
 	// PartnerAPIKey is used for tests that require a partner key (like the white label API).
 	PartnerAPIKey string
-	// ReferralAPIKey is used for tests that require a referral key (like the white label API).
+	// ReferralAPIKey is used for tests that require a referral key (like the white label API) (internal, access via ReferralAPIKey()).
 	ReferralAPIKey string
 )
 
@@ -277,6 +277,14 @@ func (c *ClientTests) PartnerClient() *easypost.Client {
 	}
 }
 
+// ReferralAPIKey returns the referral api key or a fallback if the environment variable is not set
+func (c *ClientTests) ReferralAPIKey() string {
+	if len(ReferralAPIKey) == 0 {
+		ReferralAPIKey = "123"
+	}
+	return ReferralAPIKey
+}
+
 // MockClient sets up the mock client object to be used in the test
 func (c *ClientTests) MockClient(requests []easypost.MockRequest) *easypost.Client {
 	return &easypost.Client{
@@ -327,7 +335,7 @@ func TestMain(m *testing.M) {
 	testSuite := m.Run()
 
 	// Fail test suite below desired coverage
-	// `testSuite = 0` means it passed, CoverMode will be non empty if run with -cover
+	// `testSuite = 0` means it passed, CoverMode will be non-empty if run with -cover
 	coverageMinPercentage := 0.72 // TODO: This number for whatever reason is about ~5% lower than what the CLI reports which is the real value
 	if testSuite == 0 && testing.CoverMode() != "" {
 		coverage := testing.Coverage()

--- a/tests/cassettes/TestReferralCustomerAddCreditCard.yaml
+++ b/tests/cassettes/TestReferralCustomerAddCreditCard.yaml
@@ -1,0 +1,169 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Authorization:
+      - REDACTED
+      User-Agent:
+      - REDACTED
+    url: https://api.easypost.com/v2/partners/stripe_public_key
+    method: GET
+  response:
+    body: '{"public_key":"pk_x3JSr5eOVWNTLRej8cZDde9VQ0AT5"}'
+    headers:
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"86cc970265a111486b443bf66ef85e91"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 5548df1763a39855ecd5d9a1001be379
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb5nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 29913d444b
+      - intlb1wdc 29913d444b
+      - extlb3wdc 29913d444b
+      X-Runtime:
+      - "0.015790"
+      X-Version-Label:
+      - easypost-202212212300-00650f57d8-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: card%5Bcvc%5D=778&card%5Bexp_month%5D=05&card%5Bexp_year%5D=2028&card%5Bnumber%5D=4536410136126170
+    form:
+      card[cvc]:
+      - "778"
+      card[exp_month]:
+      - "05"
+      card[exp_year]:
+      - "2028"
+      card[number]:
+      - "4536410136126170"
+    headers:
+      Authorization:
+      - REDACTED
+      Content-Type:
+      - application/x-www-form-urlencoded
+    url: https://api.stripe.com/v1/tokens
+    method: POST
+  response:
+    body: '{"card":{"address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","cvc_check":"unchecked","dynamic_last4":null,"exp_month":5,"exp_year":2028,"funding":"credit","id":"card_0MHbpCDqT4huGUvdqU4Inrj0","last4":"6170","name":null,"object":"card","tokenization_method":null},"client_ip":"REDACTED","created":1671665750,"id":"tok_0MHbpCDqT4huGUvd41R1qx19","livemode":true,"object":"token","type":"card","used":false}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - "300"
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - "720"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Dec 2022 23:35:50 GMT
+      Idempotency-Key:
+      - 0781885f-11fc-41c7-9084-f469b9325193
+      Original-Request:
+      - req_9rUsLPc1cnkL35
+      Request-Id:
+      - req_9rUsLPc1cnkL35
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Stripe-Should-Retry:
+      - "false"
+      Stripe-Version:
+      - "2020-08-27"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"credit_card":{"priority":"primary","stripe_object_id":"tok_0MHbpCDqT4huGUvd41R1qx19"}}'
+    form: {}
+    headers:
+      Authorization:
+      - REDACTED
+      Content-Type:
+      - application/json
+      User-Agent:
+      - REDACTED
+    url: https://api.easypost.com/v2/credit_cards
+    method: POST
+  response:
+    body: '{"brand":"Visa","disabled_at":null,"exp_month":5,"exp_year":2028,"id":"card_510da7c1d5ba4ec28f8e49a91fdc0ff3","last4":"6170","name":null,"object":"CreditCard"}'
+    headers:
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"f411fab263472c0d42e0f12b67445e27"
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 5548df1763a39856ecd5d9a1001be3bd
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb11nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 29913d444b
+      - intlb2wdc 29913d444b
+      - extlb3wdc 29913d444b
+      X-Runtime:
+      - "4.274109"
+      X-Version-Label:
+      - easypost-202212212300-00650f57d8-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/tests/referral_test.go
+++ b/tests/referral_test.go
@@ -60,8 +60,6 @@ func (c *ClientTests) TestReferralCustomerUpdate() {
 }
 
 func (c *ClientTests) TestReferralCustomerAddCreditCard() {
-	c.T().Skip("Because the client changes, this test cannot be recorded completely.")
-
 	client := c.PartnerClient()
 	assert, require := c.Assert(), c.Require()
 

--- a/tests/referral_test.go
+++ b/tests/referral_test.go
@@ -63,7 +63,9 @@ func (c *ClientTests) TestReferralCustomerAddCreditCard() {
 	client := c.PartnerClient()
 	assert, require := c.Assert(), c.Require()
 
-	creditCard, err := client.AddReferralCustomerCreditCard(ReferralAPIKey, c.fixture.TestCreditCard(), easypost.PrimaryPaymentMethodPriority)
+	referralAPIKey := c.ReferralAPIKey()
+
+	creditCard, err := client.AddReferralCustomerCreditCard(referralAPIKey, c.fixture.TestCreditCard(), easypost.PrimaryPaymentMethodPriority)
 	require.NoError(err)
 
 	require.Equal(reflect.TypeOf(&easypost.PaymentMethodObject{}), reflect.TypeOf(creditCard))


### PR DESCRIPTION
# Description

- Fix internal client-swapping for Stripe API calls to allow calls to be recorded

# Testing

- Re-enable referral credit card unit test

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
