### PR TITLE
add stripe refund and add payment beta functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Next Release
+
+- [ADDED] Adds new beta billing functionality for ReferralCustomer users
+  - `BetaAddPaymentMethod` can add a pre-existing Stripe bank account or credit card to your EasyPost account
+  - `BetaRefundByAmount` refunds your wallet by a dollar amount
+  - `BetaRefundByPaymentLog` refunds you wallet by a PaymentLog ID
+
 ## v2.10.0 (2022-12-07)
 
 - Routes requests for creating a carrier account with a custom workflow (eg: FedEx, UPS) to the correct endpoint when using the `CreateCarrierAccount` function

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Some tests may require an EasyPost user with a particular set of enabled feature
 
 - `USPS_CARRIER_ACCOUNT_ID` (eg: one-call buying a shipment for non-EasyPost employees)
 - `PARTNER_USER_PROD_API_KEY` (eg: creating a referral user)
-- `REFERRAL_USER_PROD_API_KEY` (eg: adding a credit card to a referral user)
+- `REFERRAL_CUSTOMER_PROD_API_KEY` (eg: adding a credit card to a referral user)
 
 #### Mocking
 

--- a/tests/bootstrap_test.go
+++ b/tests/bootstrap_test.go
@@ -277,6 +277,17 @@ func (c *ClientTests) PartnerClient() *easypost.Client {
 	}
 }
 
+// ReferralClient sets up the referral customer client object to be used in the test
+func (c *ClientTests) ReferralClient() *easypost.Client {
+	if len(ReferralAPIKey) == 0 {
+		ReferralAPIKey = "123"
+	}
+	return &easypost.Client{
+		APIKey: ReferralAPIKey,
+		Client: &http.Client{Transport: c.recorder},
+	}
+}
+
 // ReferralAPIKey returns the referral api key or a fallback if the environment variable is not set
 func (c *ClientTests) ReferralAPIKey() string {
 	if len(ReferralAPIKey) == 0 {
@@ -325,7 +336,7 @@ func TestMain(m *testing.M) {
 	fs.StringVar(
 		&ReferralAPIKey,
 		"referral-api-key",
-		os.Getenv("REFERRAL_USER_PROD_API_KEY"),
+		os.Getenv("REFERRAL_CUSTOMER_PROD_API_KEY"),
 		"production key for referral account to use against EasyPost API",
 	)
 

--- a/tests/cassettes/TestBetaReferralAddPayment.yaml
+++ b/tests/cassettes/TestBetaReferralAddPayment.yaml
@@ -1,0 +1,57 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"payment_method":{"payment_method_reference":"ba_123","priority":"primary","stripe_customer_id":"cus_123"}}'
+    form: {}
+    headers:
+      Authorization:
+      - REDACTED
+      Content-Type:
+      - application/json
+      User-Agent:
+      - REDACTED
+    url: https://api.easypost.com/beta/referral_customers/payment_method
+    method: POST
+  response:
+    body: '{"error":{"code":"BILLING.INVALID_PAYMENT_GATEWAY_REFERENCE","errors":[],"message":"Invalid
+      Payment Gateway Reference."}}'
+    headers:
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 994e51ba63bc4d3de79a8767001bd848
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb4nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq 29913d444b
+      - extlb1nuq 29913d444b
+      X-Runtime:
+      - "0.160267"
+      X-Version-Label:
+      - easypost-202301070110-985e8fd384-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 422 Unprocessable Entity
+    code: 422
+    duration: ""

--- a/tests/cassettes/TestBetaReferralRefundByAmount.yaml
+++ b/tests/cassettes/TestBetaReferralRefundByAmount.yaml
@@ -1,0 +1,57 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"refund_amount":2000}'
+    form: {}
+    headers:
+      Authorization:
+      - REDACTED
+      Content-Type:
+      - application/json
+      User-Agent:
+      - REDACTED
+    url: https://api.easypost.com/beta/referral_customers/refunds
+    method: POST
+  response:
+    body: '{"error":{"code":"TRANSACTION.AMOUNT_INVALID","errors":[],"message":"Refund
+      amount is invalid. Please use a valid amount or escalate to finance."}}'
+    headers:
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 994e51ba63bc4d3de79a8767001bd877
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb6nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 29913d444b
+      - extlb1nuq 29913d444b
+      X-Runtime:
+      - "0.461916"
+      X-Version-Label:
+      - easypost-202301070110-985e8fd384-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 422 Unprocessable Entity
+    code: 422
+    duration: ""

--- a/tests/cassettes/TestBetaReferralRefundByPaymentLogId.yaml
+++ b/tests/cassettes/TestBetaReferralRefundByPaymentLogId.yaml
@@ -1,0 +1,57 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"payment_log_id":"paylog_..."}'
+    form: {}
+    headers:
+      Authorization:
+      - REDACTED
+      Content-Type:
+      - application/json
+      User-Agent:
+      - REDACTED
+    url: https://api.easypost.com/beta/referral_customers/refunds
+    method: POST
+  response:
+    body: '{"error":{"code":"TRANSACTION.DOES_NOT_EXIST","errors":[],"message":"We
+      could not find a transaction with that id."}}'
+    headers:
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 994e51ba63bc4d3de79a8767001bd8da
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb6nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb1nuq 29913d444b
+      - extlb1nuq 29913d444b
+      X-Runtime:
+      - "0.052788"
+      X-Version-Label:
+      - easypost-202301070110-985e8fd384-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 422 Unprocessable Entity
+    code: 422
+    duration: ""

--- a/tests/referral_test.go
+++ b/tests/referral_test.go
@@ -7,6 +7,45 @@ import (
 	"github.com/EasyPost/easypost-go/v2"
 )
 
+func (c *ClientTests) TestBetaReferralAddPayment() {
+	client := c.ReferralClient()
+	assert, require := c.Assert(), c.Require()
+
+	_, err := client.BetaAddPaymentMethod("cus_123", "ba_123")
+	require.Error(err)
+	if err, ok := err.(*easypost.APIError); ok {
+		assert.Equal(422, err.StatusCode)
+		assert.Equal("BILLING.INVALID_PAYMENT_GATEWAY_REFERENCE", err.Code)
+		assert.Equal("Invalid Payment Gateway Reference.", err.Message)
+	}
+}
+
+func (c *ClientTests) TestBetaReferralRefundByAmount() {
+	client := c.ReferralClient()
+	assert, require := c.Assert(), c.Require()
+
+	_, err := client.BetaRefundByAmount(2000)
+	require.Error(err)
+	if err, ok := err.(*easypost.APIError); ok {
+		assert.Equal(422, err.StatusCode)
+		assert.Equal("TRANSACTION.AMOUNT_INVALID", err.Code)
+		assert.Equal("Refund amount is invalid. Please use a valid amount or escalate to finance.", err.Message)
+	}
+}
+
+func (c *ClientTests) TestBetaReferralRefundByPaymentLogId() {
+	client := c.ReferralClient()
+	assert, require := c.Assert(), c.Require()
+
+	_, err := client.BetaRefundByPaymentLog("paylog_...")
+	require.Error(err)
+	if err, ok := err.(*easypost.APIError); ok {
+		assert.Equal(422, err.StatusCode)
+		assert.Equal("TRANSACTION.DOES_NOT_EXIST", err.Code)
+		assert.Equal("We could not find a transaction with that id.", err.Message)
+	}
+}
+
 func (c *ClientTests) TestReferralCustomerCreate() {
 	client := c.PartnerClient()
 	assert, require := c.Assert(), c.Require()


### PR DESCRIPTION
# Description

Beta functions are added in the existing `Referral` file because there is no class and object in Go so we don't really need to create a separate beta file for it. 

- [ADDED] Adds new beta billing functionality for ReferralCustomer users
  - `BetaAddPaymentMethod` can add a pre-existing Stripe bank account or credit card to your EasyPost account
  - `BetaRefundByAmount` refunds your wallet by a dollar amount
  - `BetaRefundByPaymentLog` refunds your wallet by a PaymentLog ID
# Testing

Add unit tests and pass

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
