### PR TITLE
fix: consolidate AddPaymentMethod functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.11.1 (2023-01-11)
+
+- Removes `BetaAddPaymentMethodWithPrimaryOrSecondary` and adds the `primaryOrSecondary` parameter from that function to the `BetaAddPaymentMethod` function which was the initial intention
+
 ## v2.11.0 (2023-01-11)
 
 - Adds new beta billing functionality for ReferralCustomer users

--- a/referral_customer.go
+++ b/referral_customer.go
@@ -187,30 +187,18 @@ func (c *Client) createEasypostCreditCard(ctx context.Context, referralCustomerA
 }
 
 // BetaAddPaymentMethod adds Stripe payment method to referral customer.
-func (c *Client) BetaAddPaymentMethod(stripeCustomerId string, paymentMethodReference string) (out *PaymentMethodObject, err error) {
-	return c.BetaAddPaymentMethodWithContext(context.Background(), stripeCustomerId, paymentMethodReference)
+func (c *Client) BetaAddPaymentMethod(stripeCustomerId string, paymentMethodReference string, priority PaymentMethodPriority) (out *PaymentMethodObject, err error) {
+	return c.BetaAddPaymentMethodWithContext(context.Background(), stripeCustomerId, paymentMethodReference, priority)
 }
 
 // BetaAddPaymentMethodWithContext performs the same operation as BetaAddPaymentMethod, but allows
 // specifying a context that can interrupt the request.
-func (c *Client) BetaAddPaymentMethodWithContext(ctx context.Context, stripeCustomerId string, paymentMethodReference string) (out *PaymentMethodObject, err error) {
-	return c.BetaAddPaymentMethodWithPrimaryOrSecondaryAndContext(ctx, stripeCustomerId, paymentMethodReference, PrimaryPaymentMethodPriority)
-}
-
-// BetaAddPaymentMethodWithPrimaryOrSecondary adds Stripe payment method to referral customer with
-// PaymentMethodPriority parameter.
-func (c *Client) BetaAddPaymentMethodWithPrimaryOrSecondary(stripeCustomerId string, paymentMethodReference string, primaryOrSecondary PaymentMethodPriority) (out *PaymentMethodObject, err error) {
-	return c.BetaAddPaymentMethodWithPrimaryOrSecondaryAndContext(context.Background(), stripeCustomerId, paymentMethodReference, primaryOrSecondary)
-}
-
-// BetaAddPaymentMethodWithPrimaryOrSecondaryAndContext performs the same operation as BetaAddPaymentMethodWithPrimaryOrSecondary, but allows
-// specifying a context that can interrupt the request.
-func (c *Client) BetaAddPaymentMethodWithPrimaryOrSecondaryAndContext(ctx context.Context, stripeCustomerId string, paymentMethodReference string, primaryOrSecondary PaymentMethodPriority) (out *PaymentMethodObject, err error) {
+func (c *Client) BetaAddPaymentMethodWithContext(ctx context.Context, stripeCustomerId string, paymentMethodReference string, priority PaymentMethodPriority) (out *PaymentMethodObject, err error) {
 	wrappedParams := map[string]interface{}{
 		"payment_method": map[string]interface{}{
 			"stripe_customer_id":       stripeCustomerId,
 			"payment_method_reference": paymentMethodReference,
-			"priority":                 c.GetPaymentEndpointByPrimaryOrSecondary(primaryOrSecondary),
+			"priority":                 c.GetPaymentEndpointByPrimaryOrSecondary(priority),
 		},
 	}
 

--- a/tests/cassettes/TestBetaReferralAddPaymentMethod.yaml
+++ b/tests/cassettes/TestBetaReferralAddPaymentMethod.yaml
@@ -36,20 +36,21 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 994e51ba63bc4d3de79a8767001bd848
+      - 0698ac9263befa42e2b99038002b12a7
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb4nuq
+      - bigweb12nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
       - intlb2nuq 29913d444b
-      - extlb1nuq 29913d444b
+      - intlb2wdc 29913d444b
+      - extlb4wdc 29913d444b
       X-Runtime:
-      - "0.160267"
+      - "0.056423"
       X-Version-Label:
-      - easypost-202301070110-985e8fd384-master
+      - easypost-202301110111-1255a40c6a-master
       X-Xss-Protection:
       - 1; mode=block
     status: 422 Unprocessable Entity

--- a/tests/referral_customer_test.go
+++ b/tests/referral_customer_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/EasyPost/easypost-go/v2"
 )
 
-func (c *ClientTests) TestBetaReferralAddPayment() {
+func (c *ClientTests) TestBetaReferralAddPaymentMethod() {
 	client := c.ReferralClient()
 	assert, require := c.Assert(), c.Require()
 
-	_, err := client.BetaAddPaymentMethod("cus_123", "ba_123")
+	_, err := client.BetaAddPaymentMethod("cus_123", "ba_123", easypost.PrimaryPaymentMethodPriority)
 	require.Error(err)
 	if err, ok := err.(*easypost.APIError); ok {
 		assert.Equal(422, err.StatusCode)


### PR DESCRIPTION
# Description

Consolidates the `AddPaymentMethod` functions by removing the mistakenly included `BetaAddPaymentMethodWithPrimaryOrSecondary` and moving the `priority` param from there to the `BetaAddPaymentMethod` function since Go doesn't allow for default params, we needed to require it always. This is important because otherwise the naming is very confusing.
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Updates tests and names.
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
