### PR TITLE
Fix type mismatch on rate field of Smart Rates.

### DIFF
--- a/rate.go
+++ b/rate.go
@@ -2,6 +2,7 @@ package easypost
 
 import (
 	"context"
+	"strconv"
 	"time"
 )
 
@@ -41,11 +42,11 @@ type SmartRate struct {
 	Carrier                string         `json:"carrier,omitempty"`
 	CarrierAccountID       string         `json:"carrier_account_id,omitempty"`
 	ShipmentID             string         `json:"shipment_id,omitempty"`
-	Rate                   float64        `json:"rate,omitempty"`
+	Rate                   interface{}    `json:"rate,omitempty"`
 	Currency               string         `json:"currency,omitempty"`
-	RetailRate             float64        `json:"retail_rate,omitempty"`
+	RetailRate             interface{}    `json:"retail_rate,omitempty"`
 	RetailCurrency         string         `json:"retail_currency,omitempty"`
-	ListRate               float64        `json:"list_rate,omitempty"`
+	ListRate               interface{}    `json:"list_rate,omitempty"`
 	ListCurrency           string         `json:"list_currency,omitempty"`
 	DeliveryDays           int            `json:"delivery_days,omitempty"`
 	DeliveryDate           *time.Time     `json:"delivery_date,omitempty"`
@@ -53,6 +54,60 @@ type SmartRate struct {
 	EstDeliveryDays        int            `json:"est_delivery_days,omitempty"`
 	TimeInTransit          *TimeInTransit `json:"time_in_transit,omitempty"`
 	BillingType            string         `json:"billing_type,omitempty"`
+}
+
+func (r SmartRate) ParseRate() (float64, bool) {
+	if r.Rate == nil {
+		return 0, true
+	}
+
+	if rate, ok := r.Rate.(float64); ok {
+		return rate, true
+	}
+
+	if rateStr, ok := r.Rate.(string); ok {
+		if rate, err := strconv.ParseFloat(rateStr, 64); err == nil {
+			return rate, ok
+		}
+	}
+
+	return 0, false
+}
+
+func (r SmartRate) ParseRetailRate() (float64, bool) {
+	if r.RetailRate == nil {
+		return 0, true
+	}
+
+	if rate, ok := r.RetailRate.(float64); ok {
+		return rate, true
+	}
+
+	if rateStr, ok := r.RetailRate.(string); ok {
+		if rate, err := strconv.ParseFloat(rateStr, 64); err == nil {
+			return rate, ok
+		}
+	}
+
+	return 0, false
+}
+
+func (r SmartRate) ParseListRate() (float64, bool) {
+	if r.ListRate == nil {
+		return 0, true
+	}
+
+	if rate, ok := r.ListRate.(float64); ok {
+		return rate, true
+	}
+
+	if rateStr, ok := r.ListRate.(string); ok {
+		if rate, err := strconv.ParseFloat(rateStr, 64); err == nil {
+			return rate, ok
+		}
+	}
+
+	return 0, false
 }
 
 // A StatelessRate contains information on shipping cost and delivery time, but does not have an ID (is ephemeral).

--- a/util.go
+++ b/util.go
@@ -71,14 +71,23 @@ func (c *Client) lowestSmartRate(rates []*SmartRate, deliveryDays int, deliveryA
 			continue
 		}
 
+		// if current rate object does not have a valid rate, skip it
+		if _, ok := rate.ParseRate(); !ok {
+			continue
+		}
+
 		// if lowest rate is null, set it to this rate
 		if (out == SmartRate{}) {
 			out = *rate
 			continue
 		}
 
+		// current and out rates should be always parsable by this point as we skip all unparsable rates
+		currentRate, _ := rate.ParseRate()
+		outRate, _ := out.ParseRate()
+
 		// if this rate is lower than the lowest rate, set it to this rate
-		if 0 < rate.Rate && rate.Rate < out.Rate {
+		if 0 < currentRate && currentRate < outRate {
 			out = *rate
 		}
 	}


### PR DESCRIPTION
# Description

We encountered [issue 156](https://github.com/EasyPost/easypost-go/issues/156) where the server-side response body of Smart Rate API contains mixed string and float literals for rate-related fields. We are an existing customer and feedback have already been provided to customer support. This PR is for sharing what we had to temporarily do to unblock our development, as a reference.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
