### PR TITLE
- Dynamically parse error message when generating a APIError object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release
 
-- The `Message` attribute of an `APIError` is now a `interface{}` rather than a `string`, due to potential inconsistent data structure from the API response
+- The `Message` attribute of an `APIError` is now an `interface{}` rather than a `string`, due to potential inconsistent data structure from the API response
   - Behind-the-scenes, the `message` portion of the JSON response is transformed to a concatenated string. Users should be able to safely cast the `Message` attribute to a string when accessing it via `myApiError.Message.(string)`
 
 ## v2.14.0 (2023-04-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Next Release
+
+- The `Message` attribute of an `APIError` is now a `interface{}` rather than a `string`, due to potential inconsistent data structure from the API response
+  - Behind-the-scenes, the `message` portion of the JSON response is transformed to a concatenated string. Users should be able to safely cast the `Message` attribute to a string when accessing it via `myApiError.Message.(string)`
+
 ## v2.14.0 (2023-04-04)
 
 - Adds `GetNextXPage` functions (e.g. `GetNextShipmentPage`) to retrieve the next page of results for a provided paginated list

--- a/tests/error_test.go
+++ b/tests/error_test.go
@@ -95,13 +95,12 @@ func (c *ClientTests) TestErrorParseExtreme() {
 						"errors2": {
 							"key": {
 								"key2": "message4"
-							},
-							"key2": "message5"
+							}
 						}
 					},
-					"message6",
+					"message5",
 					{
-						"message7": "message7"
+						"message6": "message6"
 					}
 				]
 			},
@@ -118,5 +117,5 @@ func (c *ClientTests) TestErrorParseExtreme() {
 
 	errorMessage := apiErr.Message
 
-	assert.Equal("message1, message2, message3, message4, message5, message6, message7", errorMessage)
+	assert.Equal("message1, message2, message3, message4, message5, message6", errorMessage)
 }


### PR DESCRIPTION
# Description

Most of the time, the `message` property of an `APIError` object's JSON data is a string, but occasionally, our API sends something other than a string.

For example:

"message" is a JSON array
```
{
    "error": {
        ...
        "message": [
                "ERROR 1",
                "ERROR 2"
         ], 
       ...
}
```

"message" is a JSON dictionary
```
{
    "error": {
        ...
        "message": {
            "errors": [
                "ERROR 1",
                "ERROR 2"
            ]
        },
       ...
}
```

This PR enhances the JSON deserialization process for `APIError` objects to account for the "message" being an array, being a JSON dictionary, or being empty.

Shout out to @jchen293 who co-authored this but won't get credit.

# Testing

- Unit tests updated to confirm logic works as expected

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)

