### PR TITLE
[chore] Import style guide from examples submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 vendor/
 covprofile
+/.golangci.yml

--- a/Makefile
+++ b/Makefile
@@ -19,22 +19,20 @@ clean:
 coverage: 
 	go clean -testcache && go test ./tests -v -coverprofile=covprofile -coverpkg=./... && go tool cover -html=covprofile
 
-# TODO: Change branch to master once examples are merged
-## install-style - Download style guides
-install-style:
-	# curl -LJs https://raw.githubusercontent.com/EasyPost/examples/style_guides/.golangci_go_cl.yml -o .golangci.yml
-
 ## install - Install and vendor dependencies
-install: | install-style
+install: | update-examples-submodule
 	brew install golangci-lint || exit 0
-	git submodule init
-	git submodule update --remote
 	go mod vendor
 	go build -o $(PROJECT_PATH)
 
+## update-examples-submodule - Update the examples submodule
+update-examples-submodule:
+	git submodule init
+	git submodule update --remote
+
 ## lint - Lint the project
 lint:
-	golangci-lint run
+	golangci-lint run --config examples/style_guides/golang/.golangci.yml
 
 ## release - Cuts a release for the project on GitHub (requires GitHub CLI)
 # tag = The associated tag title of the release
@@ -53,4 +51,4 @@ test:
 tidy:
 	go mod tidy
 
-.PHONY: help build clean coverage install install-style lint scan test tidy
+.PHONY: help build clean coverage install install-style lint scan test tidy update-examples-submodule

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,13 @@ clean:
 coverage: 
 	go clean -testcache && go test ./tests -v -coverprofile=covprofile -coverpkg=./... && go tool cover -html=covprofile
 
+# TODO: Change branch to master once examples are merged
+## install-style - Download style guides
+install-style:
+	curl -LJs https://raw.githubusercontent.com/EasyPost/examples/style_guides/.golangci_go_cl.yml -o .golangci.yml
+
 ## install - Install and vendor dependencies
-install:
+install: | install-style
 	brew install golangci-lint || exit 0
 	git submodule init
 	git submodule update --remote
@@ -48,4 +53,4 @@ test:
 tidy:
 	go mod tidy
 
-.PHONY: help build clean coverage install lint scan test tidy
+.PHONY: help build clean coverage install install-style lint scan test tidy

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ coverage:
 # TODO: Change branch to master once examples are merged
 ## install-style - Download style guides
 install-style:
-	curl -LJs https://raw.githubusercontent.com/EasyPost/examples/style_guides/.golangci_go_cl.yml -o .golangci.yml
+	# curl -LJs https://raw.githubusercontent.com/EasyPost/examples/style_guides/.golangci_go_cl.yml -o .golangci.yml
 
 ## install - Install and vendor dependencies
 install: | install-style
@@ -34,7 +34,7 @@ install: | install-style
 
 ## lint - Lint the project
 lint:
-	golangci-lint run -e SA1019
+	golangci-lint run
 
 ## release - Cuts a release for the project on GitHub (requires GitHub CLI)
 # tag = The associated tag title of the release

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ test:
 tidy:
 	go mod tidy
 
-.PHONY: help build clean coverage install install-style lint scan test tidy update-examples-submodule
+.PHONY: help build clean coverage install lint scan test tidy update-examples-submodule


### PR DESCRIPTION
# Description

- [Reference the style guides](https://golangci-lint.run/usage/configuration/#command-line-options) from the examples submodule when formatting/linting (thankfully, no symlinking needed)
- Update Make steps, CI as needed to account for style guide imports

# Testing

- Make steps work as expected locally

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
