### PR TITLE
[chore] Fix singular/plural TrackingCode(s) parameter discrepancy

### DIFF
--- a/tracker.go
+++ b/tracker.go
@@ -86,15 +86,15 @@ type ListTrackersOptions struct {
 	StartDateTime *time.Time `url:"start_datetime,omitempty"`
 	EndDateTime   *time.Time `url:"end_datetime,omitempty"`
 	PageSize      int        `url:"page_size,omitempty"`
-	TrackingCodes []string   `url:"tracking_codes,omitempty"`
+	TrackingCode  string     `url:"tracking_code,omitempty"`
 	Carrier       string     `url:"carrier,omitempty"`
 }
 
 // ListTrackersResult holds the results from the list trackers API.
 type ListTrackersResult struct {
-	Trackers      []*Tracker `json:"trackers,omitempty"`
-	TrackingCodes []string   `json:"tracking_codes,omitempty"`
-	Carrier       string     `json:"carrier,omitempty"`
+	Trackers     []*Tracker `json:"trackers,omitempty"`
+	TrackingCode string     `json:"tracking_code,omitempty"`
+	Carrier      string     `json:"carrier,omitempty"`
 	PaginatedCollection
 }
 
@@ -189,7 +189,7 @@ func (c *Client) ListTrackers(opts *ListTrackersOptions) (out *ListTrackersResul
 func (c *Client) ListTrackersWithContext(ctx context.Context, opts *ListTrackersOptions) (out *ListTrackersResult, err error) {
 	err = c.do(ctx, http.MethodGet, "trackers", c.convertOptsToURLValues(opts), &out)
 	// Store the original query parameters for reuse when getting the next page
-	out.TrackingCodes = opts.TrackingCodes
+	out.TrackingCode = opts.TrackingCode
 	out.Carrier = opts.Carrier
 	return
 }
@@ -223,9 +223,9 @@ func (c *Client) GetNextTrackerPageWithPageSizeWithContext(ctx context.Context, 
 		return
 	}
 	trackerParams := &ListTrackersOptions{
-		BeforeID:      params.BeforeID,
-		Carrier:       collection.Carrier,
-		TrackingCodes: collection.TrackingCodes,
+		BeforeID:     params.BeforeID,
+		Carrier:      collection.Carrier,
+		TrackingCode: collection.TrackingCode,
 	}
 	if pageSize > 0 {
 		trackerParams.PageSize = pageSize


### PR DESCRIPTION
# Description

The API will soon only support providing a single tracking code as a filter when retrieving all Trackers, instead of a list of multiple tracking codes.

This PR changes the name and type restriction for the tracking code parameter in a `ListTrackerOptions` parameter set object, as well as internal storage logic for retrieving the next page of the paginated results.

This PR also updates the examples submodule to pull in the latest style guide.

# Testing

- All unit tests pass
  - Unit test passed with a new recording, but cassette does not need to be re-recorded as unit test does not use the tracking code parameter, meaning this change does not affect the cassette for the unit test.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
