### PR TITLE
[fix] FedEx SmartPost hits register endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix endpoint for creating a FedEx Smartpost carrier account
+
 ## v3.0.0 (2023-08-03)
 
 - Drop support for Go 1.15

--- a/constants.go
+++ b/constants.go
@@ -1,7 +1,7 @@
 package easypost
 
 func getCarrierAccountTypesWithCustomWorkflows() []string {
-	return []string{"FedexAccount", "UpsAccount"}
+	return []string{"FedexAccount", "UpsAccount", "FedexSmartpostAccount"}
 }
 
 var ApiDidNotReturnErrorDetails = "API did not return error details"


### PR DESCRIPTION
# Description

- FedEx SmartPost carrier account registration should hit `/register` endpoint for creation

# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
