### PR TITLE
[chore] Fix address verification unit test

### DIFF
--- a/address.go
+++ b/address.go
@@ -65,6 +65,7 @@ type Address struct {
 // CreateAddressOptions is used to specify verification options for address
 // creation.
 type CreateAddressOptions struct {
+	// TODO: These should be booleans, not strings, like the other libs
 	Verify       []string `json:"verify,omitempty"`
 	VerifyStrict []string `json:"verify_strict,omitempty"`
 }

--- a/tests/address_test.go
+++ b/tests/address_test.go
@@ -112,28 +112,38 @@ func (c *ClientTests) TestAddressCreateVerify() {
 			Verify: []string{"delivery"},
 		},
 	)
-	require.NoError(err)
 
+	// Does return an address from CreateAddress even if requested verification fails
+	require.NoError(err)
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
-	assert.True(strings.HasPrefix(address.ID, "adr_"))
-	assert.Equal("417 MONTGOMERY ST FL 5", address.Street1)
+	assert.NotNil(address.Verifications.Delivery)
 }
 
 func (c *ClientTests) TestAddressCreateAndVerify() {
 	client := c.TestClient()
 	assert, require := c.Assert(), c.Require()
 
-	address, err := client.CreateAndVerifyAddress(
+	// Creating normally (without specifying "verify") will make the address, perform no verifications
+	address, err := client.CreateAddress(
+		c.fixture.IncorrectAddress(),
+		&easypost.CreateAddressOptions{},
+	)
+	require.NoError(err)
+
+	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
+	assert.Nil(address.Verifications.Delivery)
+
+	// Creating with verify would attempt to make the address and perform verifications
+	address, err = client.CreateAndVerifyAddress(
 		c.fixture.IncorrectAddress(),
 		&easypost.CreateAddressOptions{
 			Verify: []string{"delivery"},
 		},
 	)
-	require.NoError(err)
 
-	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
-	assert.True(strings.HasPrefix(address.ID, "adr_"))
-	assert.Equal("417 MONTGOMERY ST FL 5", address.Street1)
+	// Does not return an address from CreateAndVerifyAddress if requested verification fails
+	require.Error(err)
+	assert.Nil(address)
 }
 
 func (c *ClientTests) TestAddressVerify() {

--- a/tests/cassettes/TestAddressCreateAndVerify.yaml
+++ b/tests/cassettes/TestAddressCreateAndVerify.yaml
@@ -2,8 +2,8 @@
 version: 1
 interactions:
 - request:
-    body: '{"address":{"city":"San Francisco","company":"EasyPost","country":"US","email":"REDACTED","phone":"REDACTED","state":"CA","street1":"417
-      montgomery street","street2":"FL 5","zip":"94104"},"verify":["delivery"]}'
+    body: '{"address":{"city":"Not A City","company":"EasyPost","country":"US","email":"REDACTED","phone":"REDACTED","state":"ZZ","street1":"000
+      unknown street","zip":"00001"}}'
     form: {}
     headers:
       Authorization:
@@ -12,11 +12,11 @@ interactions:
       - application/json
       User-Agent:
       - REDACTED
-    url: https://api.easypost.com/v2/addresses/create_and_verify
+    url: https://api.easypost.com/v2/addresses
     method: POST
   response:
-    body: '{"address":{"carrier_facility":null,"city":"SAN FRANCISCO","company":"EASYPOST","country":"US","created_at":"2023-11-30T20:10:16+00:00","email":"REDACTED","federal_tax_id":null,"id":"adr_7a8e29dd8fbc11eea5943cecef1b359e","mode":"test","name":null,"object":"Address","phone":"REDACTED","residential":false,"state":"CA","state_tax_id":null,"street1":"417
-      MONTGOMERY ST FL 5","street2":"","updated_at":"2023-11-30T20:10:16+00:00","verifications":{"delivery":{"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"},"errors":[],"success":true}},"zip":"94104-1129"}}'
+    body: '{"carrier_facility":null,"city":"Not A City","company":"EasyPost","country":"US","created_at":"2024-01-08T18:27:40+00:00","email":"REDACTED","federal_tax_id":null,"id":"adr_9b750f36ae5311ee8f3b3cecef1b359e","mode":"test","name":null,"object":"Address","phone":"REDACTED","residential":null,"state":"ZZ","state_tax_id":null,"street1":"000
+      unknown street","street2":null,"updated_at":"2024-01-08T18:27:40+00:00","verifications":{},"zip":"00001"}'
     headers:
       Cache-Control:
       - private, no-cache, no-store
@@ -25,7 +25,7 @@ interactions:
       Expires:
       - "0"
       Location:
-      - /api/v2/addresses/adr_7a8e29dd8fbc11eea5943cecef1b359e
+      - /api/v2/addresses/adr_9b750f36ae5311ee8f3b3cecef1b359e
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -39,22 +39,77 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 32e015fa6568ec28e7896122001b3277
+      - d1c48c8a659c3e9cf40c261200032fae
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb35nuq
+      - bigweb36nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb2nuq b3de2c47ef
+      - intlb2nuq ab82b2e6e9
       - extlb1nuq 003ad9bca0
       X-Runtime:
-      - "0.054637"
+      - "0.037722"
       X-Version-Label:
-      - easypost-202311301748-2efb918c5f-master
+      - easypost-202401051829-4cf193bd35-master
       X-Xss-Protection:
       - 1; mode=block
-    status: 200 OK
-    code: 200
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"address":{"city":"Not A City","company":"EasyPost","country":"US","email":"REDACTED","phone":"REDACTED","state":"ZZ","street1":"000
+      unknown street","zip":"00001"},"verify":["delivery"]}'
+    form: {}
+    headers:
+      Authorization:
+      - REDACTED
+      Content-Type:
+      - application/json
+      User-Agent:
+      - REDACTED
+    url: https://api.easypost.com/v2/addresses/create_and_verify
+    method: POST
+  response:
+    body: '{"error":{"code":"ADDRESS.VERIFY.FAILURE","errors":[{"code":"E.ADDRESS.NOT_FOUND","field":"address","message":"Address
+      not found","suggestion":null}],"message":"Unable to verify address."}}'
+    headers:
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - d1c48c8a659c3e9cf40c261200032fc4
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb34nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb2nuq ab82b2e6e9
+      - extlb1nuq 003ad9bca0
+      X-Runtime:
+      - "0.037967"
+      X-Version-Label:
+      - easypost-202401051829-4cf193bd35-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 422 Unprocessable Entity
+    code: 422
     duration: ""

--- a/tests/cassettes/TestAddressCreateVerify.yaml
+++ b/tests/cassettes/TestAddressCreateVerify.yaml
@@ -2,8 +2,8 @@
 version: 1
 interactions:
 - request:
-    body: '{"address":{"city":"San Francisco","company":"EasyPost","country":"US","email":"REDACTED","phone":"REDACTED","state":"CA","street1":"417
-      montgomery street","street2":"FL 5","zip":"94104"},"verify":["delivery"]}'
+    body: '{"address":{"city":"Not A City","company":"EasyPost","country":"US","email":"REDACTED","phone":"REDACTED","state":"ZZ","street1":"000
+      unknown street","zip":"00001"},"verify":["delivery"]}'
     form: {}
     headers:
       Authorization:
@@ -15,8 +15,9 @@ interactions:
     url: https://api.easypost.com/v2/addresses
     method: POST
   response:
-    body: '{"carrier_facility":null,"city":"SAN FRANCISCO","company":"EASYPOST","country":"US","created_at":"2023-11-30T20:10:16+00:00","email":"REDACTED","federal_tax_id":null,"id":"adr_7aaa30068fbc11eeace3ac1f6bc539aa","mode":"test","name":null,"object":"Address","phone":"REDACTED","residential":false,"state":"CA","state_tax_id":null,"street1":"417
-      MONTGOMERY ST FL 5","street2":"","updated_at":"2023-11-30T20:10:16+00:00","verifications":{"delivery":{"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"},"errors":[],"success":true}},"zip":"94104-1129"}'
+    body: '{"carrier_facility":null,"city":"Not A City","company":"EasyPost","country":"US","created_at":"2024-01-08T18:27:41+00:00","email":"REDACTED","federal_tax_id":null,"id":"adr_9b90cd46ae5311eebbf5ac1f6bc539ae","mode":"test","name":null,"object":"Address","phone":"REDACTED","residential":null,"state":"ZZ","state_tax_id":null,"street1":"000
+      unknown street","street2":null,"updated_at":"2024-01-08T18:27:41+00:00","verifications":{"delivery":{"details":{},"errors":[{"code":"E.ADDRESS.NOT_FOUND","field":"address","message":"Address
+      not found","suggestion":null}],"success":false}},"zip":"00001"}'
     headers:
       Cache-Control:
       - private, no-cache, no-store
@@ -25,7 +26,7 @@ interactions:
       Expires:
       - "0"
       Location:
-      - /api/v2/addresses/adr_7aaa30068fbc11eeace3ac1f6bc539aa
+      - /api/v2/addresses/adr_9b90cd46ae5311eebbf5ac1f6bc539ae
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -34,27 +35,25 @@ interactions:
       - max-age=31536000; includeSubDomains; preload
       X-Backend:
       - easypost
-      X-Canary:
-      - direct
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 32e015fa6568ec28e7896122001b32b4
+      - d1c48c8a659c3e9df40c261200032fe1
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb32nuq
+      - bigweb33nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq b3de2c47ef
+      - intlb2nuq ab82b2e6e9
       - extlb1nuq 003ad9bca0
       X-Runtime:
-      - "0.061657"
+      - "0.046836"
       X-Version-Label:
-      - easypost-202311301748-2efb918c5f-master
+      - easypost-202401051829-4cf193bd35-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created

--- a/tests/cassettes/TestAddressCreateVerifyStrict.yaml
+++ b/tests/cassettes/TestAddressCreateVerifyStrict.yaml
@@ -16,9 +16,9 @@ interactions:
     url: https://api.easypost.com/v2/addresses
     method: POST
   response:
-    body: '{"carrier_facility":null,"city":"SAN FRANCISCO","company":null,"country":"US","created_at":"2023-11-30T20:10:17+00:00","email":"REDACTED","federal_tax_id":null,"id":"adr_7ac6f0818fbc11eeaa07ac1f6bc539ae","mode":"test","name":"JACK
+    body: '{"carrier_facility":null,"city":"SAN FRANCISCO","company":null,"country":"US","created_at":"2024-01-08T18:27:41+00:00","email":"REDACTED","federal_tax_id":null,"id":"adr_9ba97ff1ae5311eebc01ac1f6bc539ae","mode":"test","name":"JACK
       SPARROW","object":"Address","phone":"REDACTED","residential":true,"state":"CA","state_tax_id":null,"street1":"388
-      TOWNSEND ST APT 20","street2":"","updated_at":"2023-11-30T20:10:17+00:00","verifications":{"delivery":{"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"},"errors":[],"success":true},"zip4":{"details":null,"errors":[],"success":true}},"zip":"94107-1670"}'
+      TOWNSEND ST APT 20","street2":"","updated_at":"2024-01-08T18:27:41+00:00","verifications":{"delivery":{"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"},"errors":[],"success":true},"zip4":{"details":null,"errors":[],"success":true}},"zip":"94107-1670"}'
     headers:
       Cache-Control:
       - private, no-cache, no-store
@@ -27,7 +27,7 @@ interactions:
       Expires:
       - "0"
       Location:
-      - /api/v2/addresses/adr_7ac6f0818fbc11eeaa07ac1f6bc539ae
+      - /api/v2/addresses/adr_9ba97ff1ae5311eebc01ac1f6bc539ae
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -41,20 +41,20 @@ interactions:
       X-Download-Options:
       - noopen
       X-Ep-Request-Uuid:
-      - 32e015fa6568ec29e7896122001b32f6
+      - d1c48c8a659c3e9df40c261200033001
       X-Frame-Options:
       - SAMEORIGIN
       X-Node:
-      - bigweb38nuq
+      - bigweb36nuq
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Proxied:
-      - intlb1nuq b3de2c47ef
+      - intlb2nuq ab82b2e6e9
       - extlb1nuq 003ad9bca0
       X-Runtime:
-      - "0.054719"
+      - "0.053186"
       X-Version-Label:
-      - easypost-202311301748-2efb918c5f-master
+      - easypost-202401051829-4cf193bd35-master
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created


### PR DESCRIPTION
# Description

See https://github.com/EasyPost/easypost-csharp/pull/540 for more details

- Update examples submodule
- Improve `TestAddressCreateAndVerify` to better test target functionality
  - Unlike other libraries that will return the Address even if it is invalid from verification, due to how Go error checking works, the Address object is not returned, only the error.

# Testing

- Update unit test, re-record cassettes as needed

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
