### PR TITLE
[bug] Fix DateTime-type objects not being encoded for HTTP payloads

### DIFF
--- a/datetime.go
+++ b/datetime.go
@@ -1,6 +1,9 @@
 package easypost
 
-import "time"
+import (
+	"net/url"
+	"time"
+)
 
 type DateTime time.Time
 
@@ -93,16 +96,21 @@ func (dt *DateTime) UnmarshalJSON(b []byte) (err error) {
 	return nil
 }
 
-func (dt DateTime) MarshalJSON() ([]byte, error) {
-	return time.Time(dt).MarshalJSON()
+func (dt *DateTime) MarshalJSON() ([]byte, error) {
+	return time.Time(*dt).MarshalJSON()
 }
 
-func (dt DateTime) String() string {
-	return time.Time(dt).String()
+func (dt *DateTime) String() string {
+	return time.Time(*dt).String()
 }
 
-func (dt DateTime) AsTime() time.Time {
-	return time.Time(dt)
+func (dt *DateTime) EncodeValues(key string, values *url.Values) error {
+	values.Set(key, time.Time(*dt).Format(time.RFC3339)) // RFC3339 is the default format for time.Time
+	return nil
+}
+
+func (dt *DateTime) AsTime() time.Time {
+	return time.Time(*dt)
 }
 
 // NewDateTime returns the DateTime corresponding to

--- a/tests/datetime_test.go
+++ b/tests/datetime_test.go
@@ -4,6 +4,8 @@ import (
 	"github.com/EasyPost/easypost-go/v4"
 	"reflect"
 	"time"
+
+	"github.com/google/go-querystring/query"
 )
 
 func (c *ClientTests) TestDateTime() {
@@ -58,4 +60,27 @@ func (c *ClientTests) TestDateTimeJSON() {
 	minDatetimeString := pickup.MinDatetime.String()
 	assert.NotNil(maxDatetimeString)
 	assert.NotNil(minDatetimeString)
+}
+
+// / TestDateTimeParameterInclusion tests that DateTime-type parameters are encoded properly (RFC3339) for use in HTTP payloads
+func (c *ClientTests) TestDateTimeParameterInclusion() {
+	assert := c.Assert()
+
+	now := time.Now().UTC()
+	past := now.AddDate(0, -4, 0)
+
+	start := easypost.DateTimeFromTime(past)
+	end := easypost.DateTimeFromTime(now)
+
+	options := easypost.ListOptions{
+		StartDateTime: &start,
+		EndDateTime:   &end,
+		PageSize:      100,
+	}
+
+	// This is the internals of the `convertOptsToURLValues` method in the `Client` struct (can't be used directly because it's private)
+	values, _ := query.Values(options)
+
+	assert.Equal(past.Format(time.RFC3339), values.Get("start_datetime"))
+	assert.Equal(now.Format(time.RFC3339), values.Get("end_datetime"))
 }


### PR DESCRIPTION
# Description

PR #184 forgot to implement the interface for allowing the custom `DateTime` class to be URL-encoded, causing any `DateTime`-type parameters (e.g. `start_datetime`, `end_datetime`) to being excluded in GET HTTP requests. POST HTTP requests were/are still valid, as the `DateTime` class was properly built to serialize to JSON data.

This PR adds the required `EncodeValues` method on the `DateTime` class to [instruct how to encode](https://zerokspot.com/weblog/2021/10/31/go-querystring/#:~:text=%7D-,Custom%20values,-When%20you%20have) the class value.

Closes #210 

# Testing

- New unit test to confirm that `DateTime` class can be URL-encoded properly.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
