### PR TITLE
[bug] Cannot determine payment method when funding/deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Fix payment method funding and deletion failures due to undetermined payment method type
 - Adds `RefundInsurance` function in Insurance service for requesting a refund for a standalone insurance
 
 ## v4.1.1 (2024-03-26)

--- a/payment_method.go
+++ b/payment_method.go
@@ -1,9 +1,5 @@
 package easypost
 
-import (
-	"strings"
-)
-
 type PaymentMethodPriority int64
 
 const (
@@ -41,9 +37,9 @@ type PaymentMethodObject struct {
 
 // getPaymentMethodObjectType returns the PaymentMethodType enum of a PaymentMethodObject.
 func (c *Client) getPaymentMethodObjectType(object *PaymentMethodObject) (out PaymentMethodType, err error) {
-	if strings.HasPrefix(object.ID, "card_") || object.Object == "CreditCard" {
+	if object.Object == "CreditCard" {
 		out = CreditCardPaymentType
-	} else if strings.HasPrefix(object.ID, "bank_") || object.Object == "BankAccount" {
+	} else if object.Object == "BankAccount" {
 		out = BankAccountPaymentType
 	} else {
 		return out, newInvalidObjectError(NoMatchingPaymentMethod)

--- a/payment_method.go
+++ b/payment_method.go
@@ -41,9 +41,9 @@ type PaymentMethodObject struct {
 
 // getPaymentMethodObjectType returns the PaymentMethodType enum of a PaymentMethodObject.
 func (c *Client) getPaymentMethodObjectType(object *PaymentMethodObject) (out PaymentMethodType, err error) {
-	if strings.HasPrefix(object.ID, "card_") {
+	if strings.HasPrefix(object.ID, "card_") || object.Object == "CreditCard" {
 		out = CreditCardPaymentType
-	} else if strings.HasPrefix(object.ID, "bank_") {
+	} else if strings.HasPrefix(object.ID, "bank_") || object.Object == "BankAccount" {
 		out = BankAccountPaymentType
 	} else {
 		return out, newInvalidObjectError(NoMatchingPaymentMethod)

--- a/tests/billing_test.go
+++ b/tests/billing_test.go
@@ -123,37 +123,3 @@ func (c *ClientTests) TestGetPaymentMethodInfoByObjectType() {
 	err := client.DeletePaymentMethod(easypost.PrimaryPaymentMethodPriority)
 	require.NoError(err)
 }
-
-func (c *ClientTests) TestGetPaymentMethodInfoByLegacyIdPrefix() {
-	mockRequests := []easypost.MockRequest{
-		{
-			MatchRule: easypost.MockRequestMatchRule{
-				Method:          "GET",
-				UrlRegexPattern: "v2\\/payment_methods$",
-			},
-			ResponseInfo: easypost.MockRequestResponseInfo{
-				StatusCode: 200,
-				Body:       `{"id": "summary_123", "primary_payment_method": {"id": "card_123", "object": null}, "secondary_payment_method": {"id": "bank_123", "object": null}}`,
-			},
-		},
-		{
-			MatchRule: easypost.MockRequestMatchRule{
-				Method:          "DELETE",
-				UrlRegexPattern: "v2\\/bank_accounts\\/bank_123$",
-			},
-			ResponseInfo: easypost.MockRequestResponseInfo{
-				StatusCode: 200,
-				Body:       `{}`,
-			},
-		},
-	}
-
-	client := c.MockClient(mockRequests)
-	require := c.Require()
-
-	// getPaymentMethodObjectType is a private method, so we can't test it directly, but we can test it via DeletePaymentMethod
-	// The mocking setup here makes it so only /v2/bank_accounts/bank_123 is allowed to be called
-	// If the method works correctly without error, we can assume it's because it found the correct payment method type
-	err := client.DeletePaymentMethod(easypost.SecondaryPaymentMethodPriority)
-	require.NoError(err)
-}

--- a/tests/billing_test.go
+++ b/tests/billing_test.go
@@ -51,7 +51,7 @@ func GetBillingMockRequests() []easypost.MockRequest {
 			},
 			ResponseInfo: easypost.MockRequestResponseInfo{
 				StatusCode: 200,
-				Body:       `{"id": "summary_123", "primary_payment_method": {"id": "card_123", "last4": "1234"}, "secondary_payment_method": {"id": "bank_123", "bank_name": "Mock Bank"}}`,
+				Body:       `{"id": "summary_123", "primary_payment_method": {"id": "pm_123", "object": "CreditCard", "last4": "1234"}, "secondary_payment_method": {"id": "pm_123", "object": "BankAccount", "bank_name": "Mock Bank"}}`,
 			},
 		},
 	}
@@ -88,4 +88,72 @@ func (c *ClientTests) TestRetrievePaymentMethods() {
 
 	assert.True(paymentMethods.PrimaryPaymentMethod != nil)
 	assert.True(paymentMethods.SecondaryPaymentMethod != nil)
+}
+
+func (c *ClientTests) TestGetPaymentMethodInfoByObjectType() {
+	mockRequests := []easypost.MockRequest{
+		{
+			MatchRule: easypost.MockRequestMatchRule{
+				Method:          "GET",
+				UrlRegexPattern: "v2\\/payment_methods$",
+			},
+			ResponseInfo: easypost.MockRequestResponseInfo{
+				StatusCode: 200,
+				Body:       `{"id": "summary_123", "primary_payment_method": {"id": "pm_123", "object": "CreditCard"}, "secondary_payment_method": {"id": "pm_123", "object": "BankAccount"}}`,
+			},
+		},
+		{
+			MatchRule: easypost.MockRequestMatchRule{
+				Method:          "DELETE",
+				UrlRegexPattern: "v2\\/credit_cards\\/pm_123$",
+			},
+			ResponseInfo: easypost.MockRequestResponseInfo{
+				StatusCode: 200,
+				Body:       `{}`,
+			},
+		},
+	}
+
+	client := c.MockClient(mockRequests)
+	require := c.Require()
+
+	// getPaymentMethodObjectType is a private method, so we can't test it directly, but we can test it via DeletePaymentMethod
+	// The mocking setup here makes it so only /v2/credit_cards/pm_123 is allowed to be called
+	// If the method works correctly without error, we can assume it's because it found the correct payment method type
+	err := client.DeletePaymentMethod(easypost.PrimaryPaymentMethodPriority)
+	require.NoError(err)
+}
+
+func (c *ClientTests) TestGetPaymentMethodInfoByLegacyIdPrefix() {
+	mockRequests := []easypost.MockRequest{
+		{
+			MatchRule: easypost.MockRequestMatchRule{
+				Method:          "GET",
+				UrlRegexPattern: "v2\\/payment_methods$",
+			},
+			ResponseInfo: easypost.MockRequestResponseInfo{
+				StatusCode: 200,
+				Body:       `{"id": "summary_123", "primary_payment_method": {"id": "card_123", "object": null}, "secondary_payment_method": {"id": "bank_123", "object": null}}`,
+			},
+		},
+		{
+			MatchRule: easypost.MockRequestMatchRule{
+				Method:          "DELETE",
+				UrlRegexPattern: "v2\\/bank_accounts\\/bank_123$",
+			},
+			ResponseInfo: easypost.MockRequestResponseInfo{
+				StatusCode: 200,
+				Body:       `{}`,
+			},
+		},
+	}
+
+	client := c.MockClient(mockRequests)
+	require := c.Require()
+
+	// getPaymentMethodObjectType is a private method, so we can't test it directly, but we can test it via DeletePaymentMethod
+	// The mocking setup here makes it so only /v2/bank_accounts/bank_123 is allowed to be called
+	// If the method works correctly without error, we can assume it's because it found the correct payment method type
+	err := client.DeletePaymentMethod(easypost.SecondaryPaymentMethodPriority)
+	require.NoError(err)
 }


### PR DESCRIPTION
# Description

- Use payment method object type when determining type for fund, delete functions

# Testing

- Update, add unit test to confirm "by object type" works to determine payment method type

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
