### PR TITLE
feat: add fields to shipment_options required by LaserShip

### DIFF
--- a/shipment_options.go
+++ b/shipment_options.go
@@ -20,11 +20,13 @@ type ShipmentOptions struct {
 	CODAddressID                string    `json:"cod_address_id,omitempty"`
 	CommercialInvoiceSignature  string    `json:"commercial_invoice_signature,omitempty"`
 	CommercialInvoiceLetterhead string    `json:"commercial_invoice_letterhead,omitempty"`
+	ContentDescription          string    `json:"content_description,omitempty"`
 	Currency                    string    `json:"currency,omitempty"`
 	DeliveryConfirmation        string    `json:"delivery_confirmation,omitempty"`
 	DeliveryMaxDatetime         *DateTime `json:"delivery_max_datetime,omitempty"`
 	DutyPayment                 *Payment  `json:"duty_payment,omitempty"`
 	DutyPaymentAccount          string    `json:"duty_payment_account,omitempty"`
+	DropoffMaxDatetime          *DateTime `json:"dropoff_max_datetime,omitempty"`
 	DropoffType                 string    `json:"dropoff_type,omitempty"`
 	DryIce                      bool      `json:"dry_ice,omitempty"`
 	DryIceMedical               bool      `json:"dry_ice_medical,omitempty,string"`
@@ -43,6 +45,7 @@ type ShipmentOptions struct {
 	Machinable                  bool      `json:"machinable,omitempty"`
 	Payment                     *Payment  `json:"payment,omitempty"`
 	PickupMinDatetime           *DateTime `json:"pickup_min_datetime,omitempty"`
+	PickupMaxDatetime           *DateTime `json:"pickup_max_datetime,omitempty"`
 	PrintCustom1                string    `json:"print_custom_1,omitempty"`
 	PrintCustom2                string    `json:"print_custom_2,omitempty"`
 	PrintCustom3                string    `json:"print_custom_3,omitempty"`


### PR DESCRIPTION
# Description

This PR adds fields used by [LaserShipV2](https://support.easypost.com/hc/en-us/articles/360062036932-Lasership-V2-Guide) carrier that were not previously present in the Go SDK. We are an existing customer of yours and have been using this custom patch in production to print LaserShip labels in non-trivial volumes for a while now.

# Testing

Regression testing via existing unit tests (`make test`) all pass successfully with our own API keys, and we have manually validated LaserShipV2 labels that were printed, as well as validating the created `shipment` entities on EasyPost dashboard.

![Screenshot from 2024-04-12 17-10-57](https://github.com/EasyPost/easypost-go/assets/126828038/6734a3b2-0deb-4f08-90f3-a5440639f00a)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
