### PR TITLE
fix: add readable and logo fields to carrier type

### DIFF
--- a/carrier.go
+++ b/carrier.go
@@ -42,9 +42,11 @@ type CarrierAccount struct {
 // CarrierType contains information on a supported carrier. It can be used to
 // determine the valid fields for a carrier account.
 type CarrierType struct {
-	Object string         `json:"object,omitempty"`
-	Type   string         `json:"type,omitempty"`
-	Fields *CarrierFields `json:"fields,omitempty"`
+	Object   string         `json:"object,omitempty"`
+	Type     string         `json:"type,omitempty"`
+	Readable string         `json:"readable,omitempty"`
+	Logo     string         `json:"logo,omitempty"`
+	Fields   *CarrierFields `json:"fields,omitempty"`
 }
 
 type carrierAccountRequest struct {


### PR DESCRIPTION
# Description

adds the missing `readable` and `logo` fields to `CarrierType`. Closes #221.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
