### PR TITLE
fix: deprecated calls to ioutil.NopCloser

### DIFF
--- a/tests/error_test.go
+++ b/tests/error_test.go
@@ -1,7 +1,7 @@
 package easypost_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -40,7 +40,7 @@ func (c *ClientTests) TestApiErrorStatusCodes() {
 
 	res := &http.Response{
 		StatusCode: 0,
-		Body:       ioutil.NopCloser(strings.NewReader("")),
+		Body:       io.NopCloser(strings.NewReader("")),
 	}
 
 	res.StatusCode = 0
@@ -198,7 +198,7 @@ func (c *ClientTests) TestApiErrorMessageParseArray() {
 
 	res := &http.Response{
 		StatusCode: 422,
-		Body:       ioutil.NopCloser(strings.NewReader(fakeErrorResponse)),
+		Body:       io.NopCloser(strings.NewReader(fakeErrorResponse)),
 	}
 
 	err := easypost.BuildErrorFromResponse(res)
@@ -225,7 +225,7 @@ func (c *ClientTests) TestErrorMessageParseMap() {
 
 	res := &http.Response{
 		StatusCode: 422,
-		Body:       ioutil.NopCloser(strings.NewReader(fakeErrorResponse)),
+		Body:       io.NopCloser(strings.NewReader(fakeErrorResponse)),
 	}
 
 	err := easypost.BuildErrorFromResponse(res)
@@ -264,7 +264,7 @@ func (c *ClientTests) TestErrorMessageParseExtreme() {
 
 	res := &http.Response{
 		StatusCode: 422,
-		Body:       ioutil.NopCloser(strings.NewReader(fakeErrorResponse)),
+		Body:       io.NopCloser(strings.NewReader(fakeErrorResponse)),
 	}
 
 	err := easypost.BuildErrorFromResponse(res)


### PR DESCRIPTION
# Description

`ioutil.NopCloser` is deprecated, all it does under the hood is call `io.NopCloser` so I swapped the calls and tests still ran
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
