### PR TITLE
fix: linting on go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,58 +10,45 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-      - name: Install dependencies
-        run: make install
+          go-version: '1.23'
         # install must occur in the same step as the linter to run properly on CI
       - name: Lint project
         run: make install lint
-
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go-version: ['1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-      - name: use golang ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: install
-        run: make install
       - name: run tests
-        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make test
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make install test
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: '1.19' # TODO: There is a bug in 1.20 that isn't calculating coverage correctly
-      - name: Install dependencies
-        run: make install
-      - name: Analyze coverage
-        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make coverage
+      - name: Run coverage report
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make install coverage
   coveralls:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
+          # NOTE: goveralls is not compatibile with go v1.22+, must remain on v1.21 max
           go-version: '1.19' # TODO: There is a bug in 1.20 that isn't calculating coverage correctly
-      - name: Install dependencies
-        run: make install
-      - name: analyze coverage
-        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make coverage
+      - name: Run coverage report
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make install coverage
       - name: Install goveralls
         env:
           GO111MODULE: off

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ init-examples-submodule:
 
 ## install - Install and vendor dependencies
 install: | init-examples-submodule
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_BIN) v1.59.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_BIN) v1.60.1
 	curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(GO_BIN)
 	go mod vendor
 

--- a/tests/bootstrap_test.go
+++ b/tests/bootstrap_test.go
@@ -240,7 +240,7 @@ func (c *ClientTests) checkExpiredCassette() {
 		currentTimestamp := time.Now()
 
 		if currentTimestamp.After(expirationTimestamp) {
-			c.T().Logf(fmt.Sprintf("%s is older than %d days and has expired. Please re-record the cassette", fullCassettePath, expirationDays))
+			c.T().Logf("%s is older than %d days and has expired. Please re-record the cassette", fullCassettePath, expirationDays)
 		}
 	}
 }


### PR DESCRIPTION
# Description

I was playing with some Go items and found why we couldn't lint on Go 1.23, fixed via this PR. Also adds some helpful notes to the coveralls section if we can ever determine why it's failing to calculate on go 1.20
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
