### PR TITLE
!fix: allow alternative error format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Next Release
 
 - Adds `WebhookCustomHeader` type, allowing `custom_headers: []WebhookCustomHeader` to be passed when creating/updating a webhook.
+- Fixes error parsing
+  - Allows for alternative format of `errors` field (previously we deserialized the `errors` field into a list of `Error` objects; however, sometimes the errors are simply a list of strings. This change makes the `errors` field an `interface`, allowing for either the renamed `FieldError` object or a list of strings. Users will need to check for the type of error returned and handle appropriately)
+  - Renamed the `Error` struct to `FieldError` to better match API docs and language
 - Removes the deprecated `create_list` tracker endpoint function as it is no longer available via API
 
 ## v4.6.0 (2024-08-16)

--- a/error.go
+++ b/error.go
@@ -227,14 +227,9 @@ func (e *APIError) Error() string {
 	switch msg := e.Message.(type) {
 	case string:
 		message = msg
-	case []interface{}:
-		var messages []string
-		for _, m := range msg {
-			messages = append(messages, fmt.Sprint(m))
-		}
+	case []interface{}, map[string]interface{}:
+		messages := collectMessages(msg, []string{})
 		message = strings.Join(messages, ", ")
-	case map[string]interface{}:
-		message = extractMessagesFromMap(msg)
 	default:
 		message = fmt.Sprint(msg)
 	}
@@ -249,25 +244,6 @@ func (e *APIError) Error() string {
 		return e.Code
 	}
 	return fmt.Sprintf("%d %s", e.StatusCode, e.Code)
-}
-
-func extractMessagesFromMap(m map[string]interface{}) string {
-	var messages []string
-	for _, v := range m {
-		switch val := v.(type) {
-		case string:
-			messages = append(messages, val)
-		case []interface{}:
-			for _, item := range val {
-				messages = append(messages, fmt.Sprint(item))
-			}
-		case map[string]interface{}:
-			messages = append(messages, extractMessagesFromMap(val))
-		default:
-			messages = append(messages, fmt.Sprint(val))
-		}
-	}
-	return strings.Join(messages, ", ")
 }
 
 func (e *APIError) Unwrap() error {

--- a/tests/address_test.go
+++ b/tests/address_test.go
@@ -1,9 +1,10 @@
 package easypost_test
 
 import (
-	"github.com/EasyPost/easypost-go/v4"
 	"reflect"
 	"strings"
+
+	"github.com/EasyPost/easypost-go/v4"
 )
 
 func (c *ClientTests) TestAddressCreate() {
@@ -116,7 +117,27 @@ func (c *ClientTests) TestAddressCreateVerify() {
 	// Does return an address from CreateAddress even if requested verification fails
 	require.NoError(err)
 	assert.Equal(reflect.TypeOf(&easypost.Address{}), reflect.TypeOf(address))
-	assert.NotNil(address.Verifications.Delivery)
+
+	// Delivery verification assertions
+	deliveryVerification := address.Verifications.Delivery
+	assert.False(deliveryVerification.Success)
+	assert.Empty(deliveryVerification.Details)
+	deliveryError := deliveryVerification.Errors[0]
+	assert.Equal("E.ADDRESS.NOT_FOUND", deliveryError.Code)
+	assert.Equal("address", deliveryError.Field)
+	assert.Empty(deliveryError.Suggestion)
+	assert.Equal("Address not found", deliveryError.Message)
+
+	// TODO: Once we send booleans instead of strings, the following will populate on the response
+	// ZIP4 verification assertions
+	// zip4Verification := address.Verifications.ZIP4
+	// assert.False(zip4Verification.Success)
+	// assert.Nil(zip4Verification.Details)
+	// zip4Error := zip4Verification.Errors[0]
+	// assert.Equal("E.ADDRESS.NOT_FOUND", zip4Error.Code)
+	// assert.Equal("address", zip4Error.Field)
+	// assert.Nil(zip4Error.Suggestion)
+	// assert.Equal("Address not found", zip4Error.Message)
 }
 
 func (c *ClientTests) TestAddressCreateAndVerify() {

--- a/tests/cassettes/TestApiErrorAlternativeFormat.yaml
+++ b/tests/cassettes/TestApiErrorAlternativeFormat.yaml
@@ -1,0 +1,59 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"contact_email":"test@example.com","description":"Test description","email_evidence_attachments":["data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg=="],"invoice_attachments":["data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg=="],"supporting_documentation_attachments":["data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg=="],"tracking_code":"123","type":"damage"}'
+    form: {}
+    headers:
+      Authorization:
+      - REDACTED
+      Content-Type:
+      - application/json
+      User-Agent:
+      - REDACTED
+    url: https://api.easypost.com/v2/claims
+    method: POST
+  response:
+    body: '{"error":{"code":"NOT_FOUND","errors":["No eligible insurance found with
+      provided tracking code."],"message":"The requested resource could not be found."}}'
+    headers:
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Ep-Request-Uuid:
+      - 170c76b967c0e1a9e7799809003a02b6
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Node:
+      - bigweb43nuq
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Proxied:
+      - intlb4nuq 51d74985a2
+      - extlb1nuq 99aac35317
+      X-Runtime:
+      - "0.032280"
+      X-Version-Label:
+      - easypost-202502272156-9473ccb478-master
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 404 Not Found
+    code: 404
+    duration: ""


### PR DESCRIPTION
# Description

- Fixes error parsing
  - Allows for alternative format of `errors` field (previously we deserialized the `errors` field into a list of `Error` objects; however, sometimes the errors are simply a list of strings. This change makes the `errors` field an `interface`, allowing for either the renamed `FieldError` object or a list of strings. Users will need to check for the type of error returned and handle appropriately)
  - Renamed the `Error` struct to `FieldError` to better match API docs and language

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Add alternative format test
- Add address verification error test

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
