### PR TITLE
fix: panic for listing resources (closes #276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v5.8.1 (2026-03-10)
+
+- Fixes the possibility for a panic when listing claims, reports, shipments, or trackers (closes #276)
+
 ## v5.8.0 (2026-02-25)
 
 - Adds generic `MakeAPICall` function

--- a/claim.go
+++ b/claim.go
@@ -92,7 +92,9 @@ func (c *Client) ListClaims(opts *ListClaimsParameters) (out *ListClaimsResult, 
 func (c *Client) ListClaimsWithContext(ctx context.Context, opts *ListClaimsParameters) (out *ListClaimsResult, err error) {
 	err = c.do(ctx, http.MethodGet, "claims", opts, &out)
 	// Store the original query parameters for reuse when getting the next page
-	out.Parameters = *opts
+	if err == nil && out != nil {
+		out.Parameters = *opts
+	}
 	return
 }
 

--- a/report.go
+++ b/report.go
@@ -61,7 +61,9 @@ func (c *Client) ListReports(typ string, opts *ListOptions) (out *ListReportsRes
 func (c *Client) ListReportsWithContext(ctx context.Context, typ string, opts *ListOptions) (out *ListReportsResult, err error) {
 	err = c.do(ctx, http.MethodGet, "reports/"+typ, opts, &out)
 	// Store the original query parameters for reuse when getting the next page
-	out.Type = typ
+	if err == nil && out != nil {
+		out.Type = typ
+	}
 	return
 }
 

--- a/shipment.go
+++ b/shipment.go
@@ -188,8 +188,10 @@ func (c *Client) ListShipments(opts *ListShipmentsOptions) (out *ListShipmentsRe
 func (c *Client) ListShipmentsWithContext(ctx context.Context, opts *ListShipmentsOptions) (out *ListShipmentsResult, err error) {
 	err = c.do(ctx, http.MethodGet, "shipments", opts, &out)
 	// Store the original query parameters for reuse when getting the next page
-	out.Purchased = opts.Purchased
-	out.IncludeChildren = opts.IncludeChildren
+	if err == nil && out != nil {
+		out.Purchased = opts.Purchased
+		out.IncludeChildren = opts.IncludeChildren
+	}
 	return
 }
 

--- a/tracker.go
+++ b/tracker.go
@@ -165,8 +165,10 @@ func (c *Client) ListTrackers(opts *ListTrackersOptions) (out *ListTrackersResul
 func (c *Client) ListTrackersWithContext(ctx context.Context, opts *ListTrackersOptions) (out *ListTrackersResult, err error) {
 	err = c.do(ctx, http.MethodGet, "trackers", opts, &out)
 	// Store the original query parameters for reuse when getting the next page
-	out.TrackingCode = opts.TrackingCode
-	out.Carrier = opts.Carrier
+	if err == nil && out != nil {
+		out.TrackingCode = opts.TrackingCode
+		out.Carrier = opts.Carrier
+	}
 	return
 }
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package easypost
 
-const Version = "5.8.0"
+const Version = "5.8.1"


### PR DESCRIPTION
# Description

It's possible a panic can occur when we try to set `out` params when it's empty because instead `err` is populated. This closes #276
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc.)
