### PR TITLE
feat: add params to RequestFedExPin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v5.9.0 (2026-06-25)
+
+- Adds `params` to `RequestFedExPin` ensuring users can pass `easypost_details` to the call
+
 ## v5.8.1 (2026-03-10)
 
 - Fixes the possibility for a panic when listing claims, reports, shipments, or trackers (closes #276)

--- a/fedex_registration.go
+++ b/fedex_registration.go
@@ -43,16 +43,15 @@ func (c *Client) RegisterFedExAddressWithContext(ctx context.Context, fedexAccou
 }
 
 // RequestFedExPin requests a PIN for FedEx account verification.
-func (c *Client) RequestFedExPin(fedexAccountNumber string, pinMethodOption string) (out *FedExRequestPinResponse, err error) {
-	return c.RequestFedExPinWithContext(context.Background(), fedexAccountNumber, pinMethodOption)
+func (c *Client) RequestFedExPin(fedexAccountNumber string, pinMethodOption string, params map[string]interface{}) (out *FedExRequestPinResponse, err error) {
+	return c.RequestFedExPinWithContext(context.Background(), fedexAccountNumber, pinMethodOption, params)
 }
 
 // RequestFedExPinWithContext performs the same operation as RequestFedExPin, but allows specifying a context that can interrupt the request.
-func (c *Client) RequestFedExPinWithContext(ctx context.Context, fedexAccountNumber string, pinMethodOption string) (out *FedExRequestPinResponse, err error) {
-	wrappedParams := map[string]interface{}{
-		"pin_method": map[string]interface{}{
-			"option": pinMethodOption,
-		},
+func (c *Client) RequestFedExPinWithContext(ctx context.Context, fedexAccountNumber string, pinMethodOption string, params map[string]interface{}) (out *FedExRequestPinResponse, err error) {
+	wrappedParams := wrapPinValidation(params)
+	wrappedParams["pin_method"] = map[string]interface{}{
+		"option": pinMethodOption,
 	}
 	endpoint := fmt.Sprintf("fedex_registrations/%s/pin", fedexAccountNumber)
 	err = c.do(ctx, http.MethodPost, endpoint, wrappedParams, &out)

--- a/fedex_registration_test.go
+++ b/fedex_registration_test.go
@@ -86,7 +86,15 @@ func (c *ClientTests) TestRequestFedExPin() {
 
 	fedexAccountNumber := "123456789"
 
-	response, err := client.RequestFedExPin(fedexAccountNumber, "SMS")
+	easypostDetails := map[string]interface{}{
+		"carrier_account_id": "ca_123",
+	}
+
+	params := map[string]interface{}{
+		"easypost_details": easypostDetails,
+	}
+
+	response, err := client.RequestFedExPin(fedexAccountNumber, "SMS", params)
 	require.NoError(err)
 
 	assert.Equal("sent secured Pin", response.Message)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package easypost
 
-const Version = "5.8.1"
+const Version = "5.9.0"


### PR DESCRIPTION
# Description

Adds `params` to `RequestFedExPin` ensuring users can pass `easypost_details` to the call.

# Testing

Updated test to accept new param.